### PR TITLE
feat: Entity simple inventory

### DIFF
--- a/src/main/java/fi/dy/masa/malilib/mixin/inventoryOwner/MixinHorseEntity.java
+++ b/src/main/java/fi/dy/masa/malilib/mixin/inventoryOwner/MixinHorseEntity.java
@@ -1,0 +1,33 @@
+package fi.dy.masa.malilib.mixin.inventoryOwner;
+
+import fi.dy.masa.malilib.util.IEntityOwnedInventory;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.passive.AbstractHorseEntity;
+import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(AbstractHorseEntity.class)
+public abstract class MixinHorseEntity extends Entity
+{
+    @Shadow protected SimpleInventory items;
+
+    public MixinHorseEntity(EntityType<?> type, World world)
+    {
+        super(type, world);
+    }
+
+    @Inject(
+            method = "onChestedStatusChanged",
+            at = @At("RETURN")
+    )
+    private void onNewInventory(CallbackInfo ci)
+    {
+        ((IEntityOwnedInventory) items).malilib$setEntityOwner(this);
+    }
+}

--- a/src/main/java/fi/dy/masa/malilib/mixin/inventoryOwner/MixinPiglinEntity.java
+++ b/src/main/java/fi/dy/masa/malilib/mixin/inventoryOwner/MixinPiglinEntity.java
@@ -1,0 +1,34 @@
+package fi.dy.masa.malilib.mixin.inventoryOwner;
+
+import fi.dy.masa.malilib.util.IEntityOwnedInventory;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.mob.PiglinEntity;
+import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PiglinEntity.class)
+public abstract class MixinPiglinEntity extends Entity
+{
+    @Shadow @Final private SimpleInventory inventory;
+
+    public MixinPiglinEntity(EntityType<?> type, World world)
+    {
+        super(type, world);
+    }
+
+    @Inject(
+            method = "<init>",
+            at = @At("RETURN")
+    )
+    private void onNewInventory(EntityType<?> entityType, World world, CallbackInfo ci)
+    {
+        ((IEntityOwnedInventory) inventory).malilib$setEntityOwner(this);
+    }
+}

--- a/src/main/java/fi/dy/masa/malilib/mixin/inventoryOwner/MixinSimpleInventory.java
+++ b/src/main/java/fi/dy/masa/malilib/mixin/inventoryOwner/MixinSimpleInventory.java
@@ -1,0 +1,26 @@
+package fi.dy.masa.malilib.mixin.inventoryOwner;
+
+import fi.dy.masa.malilib.util.IEntityOwnedInventory;
+import net.minecraft.entity.Entity;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.SimpleInventory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(SimpleInventory.class)
+public abstract class MixinSimpleInventory implements IEntityOwnedInventory, Inventory
+{
+    @Unique Entity entityOwner;
+
+    @Override
+    public Entity malilib$getEntityOwner()
+    {
+        return entityOwner;
+    }
+
+    @Override
+    public void malilib$setEntityOwner(Entity entityOwner)
+    {
+        this.entityOwner = entityOwner;
+    }
+}

--- a/src/main/java/fi/dy/masa/malilib/render/InventoryOverlay.java
+++ b/src/main/java/fi/dy/masa/malilib/render/InventoryOverlay.java
@@ -465,8 +465,10 @@ public class InventoryOverlay
 
         if (hoveredStack != null)
         {
-            drawContext.drawItemTooltip(mc.textRenderer, hoveredStack, (int) mouseX, (int) mouseY);
+            var stack = hoveredStack;
             hoveredStack = null;
+            // Some mixin / side effects can happen here
+            drawContext.drawItemTooltip(mc.textRenderer, stack, (int) mouseX, (int) mouseY);
         }
     }
 
@@ -504,8 +506,10 @@ public class InventoryOverlay
 
         if (hoveredStack != null)
         {
-            drawContext.drawItemTooltip(mc.textRenderer, hoveredStack, (int) mouseX, (int) mouseY);
+            stack = hoveredStack;
             hoveredStack = null;
+            // Some mixin / side effects can happen here, so reset hoveredStack
+            drawContext.drawItemTooltip(mc.textRenderer, stack, (int) mouseX, (int) mouseY);
         }
     }
 

--- a/src/main/java/fi/dy/masa/malilib/render/InventoryOverlay.java
+++ b/src/main/java/fi/dy/masa/malilib/render/InventoryOverlay.java
@@ -48,6 +48,8 @@ public class InventoryOverlay
             Identifier.ofVanilla("item/empty_armor_slot_chestplate"),
             Identifier.ofVanilla("item/empty_armor_slot_helmet") };
 
+    private static ItemStack hoveredStack = null;
+
     public static void renderInventoryBackground(InventoryRenderType type, int x, int y, int slotsPerRow, int totalSlots, MinecraftClient mc)
     {
         RenderUtils.setupBlend();
@@ -460,6 +462,12 @@ public class InventoryOverlay
                 y += 18;
             }
         }
+
+        if (hoveredStack != null)
+        {
+            drawContext.drawItemTooltip(mc.textRenderer, hoveredStack, (int) mouseX, (int) mouseY);
+            hoveredStack = null;
+        }
     }
 
     public static void renderEquipmentStacks(LivingEntity entity, int x, int y, MinecraftClient mc, DrawContext drawContext)
@@ -492,6 +500,12 @@ public class InventoryOverlay
         if (stack.isEmpty() == false)
         {
             renderStackAt(stack, x + 28, y + 3 * 18 + 7 + 1, 1, mc, drawContext, mouseX, mouseY);
+        }
+
+        if (hoveredStack != null)
+        {
+            drawContext.drawItemTooltip(mc.textRenderer, hoveredStack, (int) mouseX, (int) mouseY);
+            hoveredStack = null;
         }
     }
 
@@ -549,7 +563,7 @@ public class InventoryOverlay
         matrixStack.pop();
         if (mouseX >= x && mouseX < x + 16 * scale && mouseY >= y && mouseY < y + 16 * scale)
         {
-            drawContext.drawItemTooltip(mc.textRenderer, stack, (int) mouseX, (int) mouseY);
+            hoveredStack = stack;
         }
     }
 

--- a/src/main/java/fi/dy/masa/malilib/render/InventoryOverlay.java
+++ b/src/main/java/fi/dy/masa/malilib/render/InventoryOverlay.java
@@ -412,19 +412,24 @@ public class InventoryOverlay
 
     public static void renderInventoryStacks(InventoryRenderType type, Inventory inv, int startX, int startY, int slotsPerRow, int startSlot, int maxSlots, MinecraftClient mc, DrawContext drawContext)
     {
+        renderInventoryStacks(type, inv, startX, startY, slotsPerRow, startSlot, maxSlots, mc, drawContext, 0, 0);
+    }
+
+    public static void renderInventoryStacks(InventoryRenderType type, Inventory inv, int startX, int startY, int slotsPerRow, int startSlot, int maxSlots, MinecraftClient mc, DrawContext drawContext, double mouseX, double mouseY)
+    {
         if (type == InventoryRenderType.FURNACE)
         {
-            renderStackAt(inv.getStack(0), startX +   8, startY +  8, 1, mc, drawContext);
-            renderStackAt(inv.getStack(1), startX +   8, startY + 44, 1, mc, drawContext);
-            renderStackAt(inv.getStack(2), startX +  68, startY + 26, 1, mc, drawContext);
+            renderStackAt(inv.getStack(0), startX +   8, startY +  8, 1, mc, drawContext, mouseX, mouseY);
+            renderStackAt(inv.getStack(1), startX +   8, startY + 44, 1, mc, drawContext, mouseX, mouseY);
+            renderStackAt(inv.getStack(2), startX +  68, startY + 26, 1, mc, drawContext, mouseX, mouseY);
         }
         else if (type == InventoryRenderType.BREWING_STAND)
         {
-            renderStackAt(inv.getStack(0), startX +  47, startY + 42, 1, mc, drawContext);
-            renderStackAt(inv.getStack(1), startX +  70, startY + 49, 1, mc, drawContext);
-            renderStackAt(inv.getStack(2), startX +  93, startY + 42, 1, mc, drawContext);
-            renderStackAt(inv.getStack(3), startX +  70, startY +  8, 1, mc, drawContext);
-            renderStackAt(inv.getStack(4), startX +   8, startY +  8, 1, mc, drawContext);
+            renderStackAt(inv.getStack(0), startX +  47, startY + 42, 1, mc, drawContext, mouseX, mouseY);
+            renderStackAt(inv.getStack(1), startX +  70, startY + 49, 1, mc, drawContext, mouseX, mouseY);
+            renderStackAt(inv.getStack(2), startX +  93, startY + 42, 1, mc, drawContext, mouseX, mouseY);
+            renderStackAt(inv.getStack(3), startX +  70, startY +  8, 1, mc, drawContext, mouseX, mouseY);
+            renderStackAt(inv.getStack(4), startX +   8, startY +  8, 1, mc, drawContext, mouseX, mouseY);
         }
         else
         {
@@ -445,7 +450,7 @@ public class InventoryOverlay
 
                     if (stack.isEmpty() == false)
                     {
-                        renderStackAt(stack, x, y, 1, mc, drawContext);
+                        renderStackAt(stack, x, y, 1, mc, drawContext, mouseX, mouseY);
                     }
 
                     x += 18;
@@ -517,6 +522,11 @@ public class InventoryOverlay
 
     public static void renderStackAt(ItemStack stack, float x, float y, float scale, MinecraftClient mc, DrawContext drawContext)
     {
+        renderStackAt(stack, x, y, scale, mc, drawContext, 0, 0);
+    }
+
+    public static void renderStackAt(ItemStack stack, float x, float y, float scale, MinecraftClient mc, DrawContext drawContext, double mouseX, double mouseY)
+    {
         MatrixStack matrixStack = drawContext.getMatrices();
         matrixStack.push();
         matrixStack.translate(x, y, 0.f);
@@ -532,6 +542,10 @@ public class InventoryOverlay
 
         RenderUtils.color(1f, 1f, 1f, 1f);
         matrixStack.pop();
+        if (mouseX >= x && mouseX < x + 16 * scale && mouseY >= y && mouseY < y + 16 * scale)
+        {
+            renderStackToolTip((int) mouseX, (int) mouseY, stack, mc, drawContext);
+        }
     }
 
     public static void renderStackToolTip(int x, int y, ItemStack stack, MinecraftClient mc, DrawContext drawContext)

--- a/src/main/java/fi/dy/masa/malilib/render/InventoryOverlay.java
+++ b/src/main/java/fi/dy/masa/malilib/render/InventoryOverlay.java
@@ -464,6 +464,11 @@ public class InventoryOverlay
 
     public static void renderEquipmentStacks(LivingEntity entity, int x, int y, MinecraftClient mc, DrawContext drawContext)
     {
+        renderEquipmentStacks(entity, x, y, mc, drawContext, 0, 0);
+    }
+
+    public static void renderEquipmentStacks(LivingEntity entity, int x, int y, MinecraftClient mc, DrawContext drawContext, double mouseX, double mouseY)
+    {
         for (int i = 0, xOff = 7, yOff = 7; i < 4; ++i, yOff += 18)
         {
             final EquipmentSlot eqSlot = VALID_EQUIPMENT_SLOTS[i];
@@ -471,7 +476,7 @@ public class InventoryOverlay
 
             if (stack.isEmpty() == false)
             {
-                renderStackAt(stack, x + xOff + 1, y + yOff + 1, 1, mc, drawContext);
+                renderStackAt(stack, x + xOff + 1, y + yOff + 1, 1, mc, drawContext, mouseX, mouseY);
             }
         }
 
@@ -479,14 +484,14 @@ public class InventoryOverlay
 
         if (stack.isEmpty() == false)
         {
-            renderStackAt(stack, x + 28, y + 2 * 18 + 7 + 1, 1, mc, drawContext);
+            renderStackAt(stack, x + 28, y + 2 * 18 + 7 + 1, 1, mc, drawContext, mouseX, mouseY);
         }
 
         stack = entity.getEquippedStack(EquipmentSlot.OFFHAND);
 
         if (stack.isEmpty() == false)
         {
-            renderStackAt(stack, x + 28, y + 3 * 18 + 7 + 1, 1, mc, drawContext);
+            renderStackAt(stack, x + 28, y + 3 * 18 + 7 + 1, 1, mc, drawContext, mouseX, mouseY);
         }
     }
 
@@ -544,7 +549,7 @@ public class InventoryOverlay
         matrixStack.pop();
         if (mouseX >= x && mouseX < x + 16 * scale && mouseY >= y && mouseY < y + 16 * scale)
         {
-            renderStackToolTip((int) mouseX, (int) mouseY, stack, mc, drawContext);
+            drawContext.drawItemTooltip(mc.textRenderer, stack, (int) mouseX, (int) mouseY);
         }
     }
 

--- a/src/main/java/fi/dy/masa/malilib/render/InventoryOverlay.java
+++ b/src/main/java/fi/dy/masa/malilib/render/InventoryOverlay.java
@@ -3,6 +3,7 @@ package fi.dy.masa.malilib.render;
 import java.util.ArrayList;
 import java.util.List;
 import com.mojang.blaze3d.systems.RenderSystem;
+import fi.dy.masa.malilib.util.IEntityOwnedInventory;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.*;
 import net.minecraft.client.MinecraftClient;
@@ -11,9 +12,11 @@ import net.minecraft.client.render.*;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.PiglinEntity;
+import net.minecraft.entity.passive.AbstractHorseEntity;
+import net.minecraft.entity.passive.HorseEntity;
 import net.minecraft.inventory.DoubleInventory;
 import net.minecraft.inventory.Inventory;
-import net.minecraft.inventory.SimpleInventory;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -265,14 +268,18 @@ public class InventoryOverlay
         {
             return InventoryRenderType.HOPPER;
         }
-        else if (inv.getClass() == SimpleInventory.class) // FIXME
+        else if (inv instanceof IEntityOwnedInventory inventory)
         {
-            return InventoryRenderType.HORSE;
+            if (inventory.malilib$getEntityOwner() instanceof AbstractHorseEntity)
+            {
+                return InventoryRenderType.HORSE;
+            }
+            else if (inventory.malilib$getEntityOwner() instanceof PiglinEntity)
+            {
+                return InventoryRenderType.VILLAGER;
+            }
         }
-        else
-        {
-            return InventoryRenderType.GENERIC;
-        }
+        return InventoryRenderType.GENERIC;
     }
 
     public static InventoryRenderType getInventoryType(ItemStack stack)

--- a/src/main/java/fi/dy/masa/malilib/util/IEntityOwnedInventory.java
+++ b/src/main/java/fi/dy/masa/malilib/util/IEntityOwnedInventory.java
@@ -1,0 +1,9 @@
+package fi.dy.masa.malilib.util;
+
+import net.minecraft.entity.Entity;
+
+public interface IEntityOwnedInventory
+{
+    Entity malilib$getEntityOwner();
+    void malilib$setEntityOwner(Entity entity);
+}

--- a/src/main/resources/mixins.malilib.json
+++ b/src/main/resources/mixins.malilib.json
@@ -1,25 +1,28 @@
 {
-    "required": true,
-    "package": "fi.dy.masa.malilib.mixin",
-    "compatibilityLevel": "JAVA_17",
-    "minVersion": "0.8",
-    "client": [
-        "IMixinBufferBuilder",
-        "MixinClientConfigurationNetworkHandler",
-        "MixinClientPlayNetworkHandler",
-        "MixinDrawContext",
-        "MixinHandledScreen",
-        "MixinInGameHud",
-        "MixinIntegratedServer",
-        "MixinKeyboard",
-        "MixinMinecraftClient",
-        "MixinMouse",
-        "MixinWorldRenderer"
-    ],
-    "mixins": [
-        "MixinMinecraftServer"
-    ],
-    "injectors": {
-        "defaultRequire": 1
+  "required": true,
+  "package": "fi.dy.masa.malilib.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "minVersion": "0.8",
+  "client": [
+    "IMixinBufferBuilder",
+    "MixinClientConfigurationNetworkHandler",
+    "MixinClientPlayNetworkHandler",
+    "MixinDrawContext",
+    "MixinHandledScreen",
+    "MixinInGameHud",
+    "MixinIntegratedServer",
+    "MixinKeyboard",
+    "MixinMinecraftClient",
+    "MixinMouse",
+    "MixinWorldRenderer"
+  ],
+  "mixins": [
+    "MixinMinecraftServer",
+    "inventoryOwner.MixinHorseEntity",
+    "inventoryOwner.MixinPiglinEntity",
+    "inventoryOwner.MixinSimpleInventory"
+  ],
+  "injectors": {
+    "defaultRequire": 1
   }
 }

--- a/src/main/resources/mixins.malilib.json
+++ b/src/main/resources/mixins.malilib.json
@@ -1,28 +1,26 @@
 {
-  "required": true,
-  "package": "fi.dy.masa.malilib.mixin",
-  "compatibilityLevel": "JAVA_17",
-  "minVersion": "0.8",
-  "client": [
-    "IMixinBufferBuilder",
-    "MixinClientConfigurationNetworkHandler",
-    "MixinClientPlayNetworkHandler",
-    "MixinDrawContext",
-    "MixinHandledScreen",
-    "MixinInGameHud",
-    "MixinIntegratedServer",
-    "MixinKeyboard",
-    "MixinMinecraftClient",
-    "MixinMouse",
-    "MixinWorldRenderer"
-  ],
-  "mixins": [
-    "MixinMinecraftServer",
-    "inventoryOwner.MixinHorseEntity",
-    "inventoryOwner.MixinPiglinEntity",
-    "inventoryOwner.MixinSimpleInventory"
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  }
+    "required": true,
+    "package": "fi.dy.masa.malilib.mixin",
+    "compatibilityLevel": "JAVA_17",
+    "minVersion": "0.8",
+    "client": [
+        "IMixinBufferBuilder",
+        "MixinClientConfigurationNetworkHandler",
+        "MixinClientPlayNetworkHandler",
+        "MixinDrawContext",
+        "MixinHandledScreen",
+        "MixinInGameHud",
+        "MixinIntegratedServer",
+        "MixinKeyboard",
+        "MixinMinecraftClient",
+        "MixinMouse",
+        "MixinWorldRenderer",
+        "MixinMinecraftServer",
+        "inventoryOwner.MixinHorseEntity",
+        "inventoryOwner.MixinPiglinEntity",
+        "inventoryOwner.MixinSimpleInventory"
+    ],
+    "injectors": {
+        "defaultRequire": 1
+    }
 }


### PR DESCRIPTION
Previously, if the inventory is `SimpleInventory`, malilib thinks it is owned by a horse, that is inaccurate.

In this PR, I also added support to piglin's inventory (using villager's type).

Also made the item renderer methods accepts mouseX and mouseY, for https://github.com/sakura-ryoko/minihud/pull/8