### PR TITLE
Revert Fix: set translatedName for more complex config types

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ author = masa
 mod_file_name = malilib-fabric
 
 # Current mod version
-mod_version = 0.19.999-sakura.6-translations.4
+mod_version = 0.19.999-sakura.6-translations.5
 
 # Minecraft, Fabric Loader and API and mappings versions
 minecraft_version_out = 1.21

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigBase.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigBase.java
@@ -25,16 +25,11 @@ public abstract class ConfigBase<T extends IConfigBase> implements IConfigBase, 
 
     public ConfigBase(ConfigType type, String name, String comment, String prettyName)
     {
-        this(type, name, comment, prettyName, name);
-    }
-
-    public ConfigBase(ConfigType type, String name, String comment, String prettyName, String translatedName)
-    {
         this.type = type;
         this.name = name;
-        this.comment = comment;
         this.prettyName = prettyName;
-        this.translatedName = translatedName;
+        this.comment = comment;
+        this.translatedName = name;
     }
 
     @Override

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigBoolean.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigBoolean.java
@@ -18,12 +18,7 @@ public class ConfigBoolean extends ConfigBase<ConfigBoolean> implements IConfigB
 
     public ConfigBoolean(String name, boolean defaultValue, String comment, String prettyName)
     {
-        this(name, defaultValue, comment, prettyName, name);
-    }
-
-    public ConfigBoolean(String name, boolean defaultValue, String comment, String prettyName, String translatedName)
-    {
-        super(ConfigType.BOOLEAN, name, comment, prettyName, translatedName);
+        super(ConfigType.BOOLEAN, name, comment, prettyName);
 
         this.defaultValue = defaultValue;
         this.value = defaultValue;

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigBooleanHotkeyed.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigBooleanHotkeyed.java
@@ -22,17 +22,12 @@ public class ConfigBooleanHotkeyed extends ConfigBoolean implements IHotkeyToggl
 
     public ConfigBooleanHotkeyed(String name, boolean defaultValue, String defaultHotkey, String comment, String prettyName)
     {
-        this(name, defaultValue, defaultHotkey, KeybindSettings.DEFAULT, comment, prettyName, name);
+        this(name, defaultValue, defaultHotkey, KeybindSettings.DEFAULT, comment, prettyName);
     }
 
     public ConfigBooleanHotkeyed(String name, boolean defaultValue, String defaultHotkey, KeybindSettings settings, String comment, String prettyName)
     {
-        this(name, defaultValue, defaultHotkey, settings, comment, prettyName, name);
-    }
-
-    public ConfigBooleanHotkeyed(String name, boolean defaultValue, String defaultHotkey, KeybindSettings settings, String comment, String prettyName, String translatedName)
-    {
-        super(name, defaultValue, comment, prettyName, translatedName);
+        super(name, defaultValue, comment, prettyName);
 
         this.keybind = KeybindMulti.fromStorageString(defaultHotkey, settings);
         this.keybind.setCallback(new KeyCallbackToggleBooleanConfigWithMessage(this));

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigColor.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigColor.java
@@ -11,21 +11,16 @@ public class ConfigColor extends ConfigInteger
 {
     private Color4f color;
 
+    public ConfigColor(String name, String defaultValue, String comment, String prettyName)
+    {
+        super(name, StringUtils.getColor(defaultValue, 0), comment, prettyName);
+
+        this.color = Color4f.fromColor(this.getIntegerValue());
+    }
+
     public ConfigColor(String name, String defaultValue, String comment)
     {
         this(name, defaultValue, comment, name);
-    }
-
-    public ConfigColor(String name, String defaultValue, String comment, String prettyName)
-    {
-        this(name, defaultValue, comment, prettyName, name);
-    }
-
-    public ConfigColor(String name, String defaultValue, String comment, String prettyName, String translatedName)
-    {
-        super(name, StringUtils.getColor(defaultValue, 0), comment, prettyName, translatedName);
-
-        this.color = Color4f.fromColor(this.getIntegerValue());
     }
 
     @Override
@@ -78,7 +73,7 @@ public class ConfigColor extends ConfigInteger
         {
             return StringUtils.getColor(newValue, 0) != this.getDefaultIntegerValue();
         }
-        catch (Exception ignored)
+        catch (Exception e)
         {
         }
 

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigColorList.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigColorList.java
@@ -20,17 +20,15 @@ public class ConfigColorList extends ConfigBase<ConfigColorList> implements ICon
 
     public ConfigColorList(String name, ImmutableList<Color4f> defaultValue, String comment)
     {
-        this(name, defaultValue, comment, name);
+        super(ConfigType.COLOR_LIST, name, comment);
+
+        this.defaultValue = defaultValue;
+        this.colors.addAll(defaultValue);
     }
 
     public ConfigColorList(String name, ImmutableList<Color4f> defaultValue, String comment, String prettyName)
     {
-        this(name, defaultValue, comment, prettyName, name);
-    }
-
-    public ConfigColorList(String name, ImmutableList<Color4f> defaultValue, String comment, String prettyName, String translatedName)
-    {
-        super(ConfigType.COLOR_LIST, name, comment, prettyName, translatedName);
+        super(ConfigType.COLOR_LIST, name, comment, prettyName);
 
         this.defaultValue = defaultValue;
         this.colors.addAll(defaultValue);

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigDouble.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigDouble.java
@@ -22,32 +22,22 @@ public class ConfigDouble extends ConfigBase<ConfigDouble> implements IConfigDou
 
     public ConfigDouble(String name, double defaultValue, String comment, String prettyName)
     {
-        this(name, defaultValue, Double.MIN_VALUE, Double.MAX_VALUE, comment, prettyName, name);
-    }
-
-    public ConfigDouble(String name, double defaultValue, String comment, String prettyName, String translatedName)
-    {
-        this(name, defaultValue, Double.MIN_VALUE, Double.MAX_VALUE, comment, prettyName, translatedName);
+        this(name, defaultValue, Double.MIN_VALUE, Double.MAX_VALUE, comment, prettyName);
     }
 
     public ConfigDouble(String name, double defaultValue, double minValue, double maxValue, String comment)
     {
-        this(name, defaultValue, minValue, maxValue, comment, name);
+        this(name, defaultValue, minValue, maxValue, false, comment, name);
     }
 
     public ConfigDouble(String name, double defaultValue, double minValue, double maxValue, String comment, String prettyName)
     {
-        this(name, defaultValue, minValue, maxValue, false, comment, prettyName, name);
+        this(name, defaultValue, minValue, maxValue, false, comment, prettyName);
     }
 
-    public ConfigDouble(String name, double defaultValue, double minValue, double maxValue, String comment, String prettyName, String translatedName)
+    public ConfigDouble(String name, double defaultValue, double minValue, double maxValue, boolean useSlider, String comment, String prettyName)
     {
-        this(name, defaultValue, minValue, maxValue, false, comment, prettyName, translatedName);
-    }
-
-    public ConfigDouble(String name, double defaultValue, double minValue, double maxValue, boolean useSlider, String comment, String prettyName, String translatedName)
-    {
-        super(ConfigType.DOUBLE, name, comment, prettyName, translatedName);
+        super(ConfigType.DOUBLE, name, comment, prettyName);
 
         this.minValue = minValue;
         this.maxValue = maxValue;
@@ -122,7 +112,7 @@ public class ConfigDouble extends ConfigBase<ConfigDouble> implements IConfigDou
         {
             return Double.parseDouble(newValue) != this.defaultValue;
         }
-        catch (Exception ignored)
+        catch (Exception e)
         {
         }
 

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigHotkey.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigHotkey.java
@@ -18,29 +18,19 @@ public class ConfigHotkey extends ConfigBase<ConfigHotkey> implements IHotkey
         this(name, defaultStorageString, comment, name);
     }
 
-    public ConfigHotkey(String name, String defaultStorageString, String comment, String prettyName)
-    {
-        this(name, defaultStorageString, KeybindSettings.DEFAULT, comment, prettyName, name);
-    }
-
-    public ConfigHotkey(String name, String defaultStorageString, String comment, String prettyName, String translatedName)
-    {
-        this(name, defaultStorageString, KeybindSettings.DEFAULT, comment, prettyName, translatedName);
-    }
-
     public ConfigHotkey(String name, String defaultStorageString, KeybindSettings settings, String comment)
     {
-        this(name, defaultStorageString, settings, comment, StringUtils.splitCamelCase(name), name);
+        this(name, defaultStorageString, settings, comment, StringUtils.splitCamelCase(name));
+    }
+
+    public ConfigHotkey(String name, String defaultStorageString, String comment, String prettyName)
+    {
+        this(name, defaultStorageString, KeybindSettings.DEFAULT, comment, prettyName);
     }
 
     public ConfigHotkey(String name, String defaultStorageString, KeybindSettings settings, String comment, String prettyName)
     {
-        this(name, defaultStorageString, settings, comment, prettyName, name);
-    }
-
-    public ConfigHotkey(String name, String defaultStorageString, KeybindSettings settings, String comment, String prettyName, String translatedName)
-    {
-        super(ConfigType.HOTKEY, name, comment, prettyName, translatedName);
+        super(ConfigType.HOTKEY, name, comment, prettyName);
 
         this.keybind = KeybindMulti.fromStorageString(defaultStorageString, settings);
     }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigInteger.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigInteger.java
@@ -22,37 +22,27 @@ public class ConfigInteger extends ConfigBase<ConfigInteger> implements IConfigI
 
     public ConfigInteger(String name, int defaultValue, String comment, String prettyName)
     {
-        this(name, defaultValue, Integer.MIN_VALUE, Integer.MAX_VALUE, comment, prettyName, name);
-    }
-
-    public ConfigInteger(String name, int defaultValue, String comment, String prettyName, String translatedName)
-    {
-        this(name, defaultValue, Integer.MIN_VALUE, Integer.MAX_VALUE, comment, prettyName, translatedName);
+        this(name, defaultValue, Integer.MIN_VALUE, Integer.MAX_VALUE, comment, prettyName);
     }
 
     public ConfigInteger(String name, int defaultValue, int minValue, int maxValue, String comment)
     {
-        this(name, defaultValue, minValue, maxValue, false, comment, name, name);
+        this(name, defaultValue, minValue, maxValue, false, comment, name);
     }
 
     public ConfigInteger(String name, int defaultValue, int minValue, int maxValue, String comment, String prettyName)
     {
-        this(name, defaultValue, minValue, maxValue, false, comment, prettyName, name);
-    }
-
-    public ConfigInteger(String name, int defaultValue, int minValue, int maxValue, String comment, String prettyName, String translatedName)
-    {
-        this(name, defaultValue, minValue, maxValue, false, comment, prettyName, translatedName);
+        this(name, defaultValue, minValue, maxValue, false, comment, prettyName);
     }
 
     public ConfigInteger(String name, int defaultValue, int minValue, int maxValue, boolean useSlider, String comment)
     {
-        this(name, defaultValue, minValue, maxValue, useSlider, comment, name, name);
+        this(name, defaultValue, minValue, maxValue, useSlider, comment, name);
     }
 
-    public ConfigInteger(String name, int defaultValue, int minValue, int maxValue, boolean useSlider, String comment, String prettyName, String translatedName)
+    public ConfigInteger(String name, int defaultValue, int minValue, int maxValue, boolean useSlider, String comment, String prettyName)
     {
-        super(ConfigType.INTEGER, name, comment, prettyName, translatedName);
+        super(ConfigType.INTEGER, name, comment, prettyName);
 
         this.minValue = minValue;
         this.maxValue = maxValue;
@@ -127,7 +117,7 @@ public class ConfigInteger extends ConfigBase<ConfigInteger> implements IConfigI
         {
             return Integer.parseInt(newValue) != this.defaultValue;
         }
-        catch (Exception ignored)
+        catch (Exception e)
         {
         }
 

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigOptionList.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigOptionList.java
@@ -20,12 +20,7 @@ public class ConfigOptionList extends ConfigBase<ConfigOptionList> implements IC
 
     public ConfigOptionList(String name, IConfigOptionListEntry defaultValue, String comment, String prettyName)
     {
-        this(name, defaultValue, comment, prettyName, name);
-    }
-
-    public ConfigOptionList(String name, IConfigOptionListEntry defaultValue, String comment, String prettyName, String translatedName)
-    {
-        super(ConfigType.OPTION_LIST, name, comment, prettyName, translatedName);
+        super(ConfigType.OPTION_LIST, name, comment, prettyName);
 
         this.defaultValue = defaultValue;
         this.value = defaultValue;
@@ -68,7 +63,7 @@ public class ConfigOptionList extends ConfigBase<ConfigOptionList> implements IC
         {
             return this.value.fromString(newValue) != this.defaultValue;
         }
-        catch (Exception ignored)
+        catch (Exception e)
         {
         }
 

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigString.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigString.java
@@ -19,12 +19,7 @@ public class ConfigString extends ConfigBase<ConfigString> implements IConfigVal
 
     public ConfigString(String name, String defaultValue, String comment, String prettyName)
     {
-        this(name, defaultValue, comment, prettyName, name);
-    }
-
-    public ConfigString(String name, String defaultValue, String comment, String prettyName, String translatedName)
-    {
-        super(ConfigType.STRING, name, comment, prettyName, translatedName);
+        super(ConfigType.STRING, name, comment, prettyName);
 
         this.defaultValue = defaultValue;
         this.value = defaultValue;

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigStringList.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigStringList.java
@@ -22,12 +22,7 @@ public class ConfigStringList extends ConfigBase<ConfigStringList> implements IC
 
     public ConfigStringList(String name, ImmutableList<String> defaultValue, String comment, String prettyName)
     {
-        this(name, defaultValue, comment, prettyName, name);
-    }
-
-    public ConfigStringList(String name, ImmutableList<String> defaultValue, String comment, String prettyName, String translatedName)
-    {
-        super(ConfigType.STRING_LIST, name, comment, prettyName, translatedName);
+        super(ConfigType.STRING_LIST, name, comment, prettyName);
 
         this.defaultValue = defaultValue;
         this.strings.addAll(defaultValue);

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigTypeWrapper.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigTypeWrapper.java
@@ -48,11 +48,11 @@ public class ConfigTypeWrapper implements IConfigBoolean, IConfigDouble, IConfig
     {
         if (this.wrappedConfig instanceof IConfigInteger)
         {
-            ((IConfigInteger) this.wrappedConfig).toggleUseSlider();
+            ((IConfigInteger) this.wrappedConfig).toggleUseSlider();;
         }
         else if (this.wrappedConfig instanceof IConfigDouble)
         {
-            ((IConfigDouble) this.wrappedConfig).toggleUseSlider();
+            ((IConfigDouble) this.wrappedConfig).toggleUseSlider();;
         }
     }
 
@@ -115,31 +115,33 @@ public class ConfigTypeWrapper implements IConfigBoolean, IConfigDouble, IConfig
     @Override
     public String getStringValue()
     {
-        return switch (this.wrappedType)
+        switch (this.wrappedType)
         {
-            case BOOLEAN -> String.valueOf(((IConfigBoolean) this.wrappedConfig).getBooleanValue());
-            case DOUBLE -> String.valueOf(((IConfigDouble) this.wrappedConfig).getDoubleValue());
-            case INTEGER -> String.valueOf(((IConfigInteger) this.wrappedConfig).getIntegerValue());
-            case COLOR -> String.format("#%08X", ((IConfigInteger) this.wrappedConfig).getIntegerValue());
-            case OPTION_LIST -> ((IConfigOptionList) this.wrappedConfig).getOptionListValue().getStringValue();
-            case HOTKEY -> ((IHotkey) this.wrappedConfig).getKeybind().getStringValue();
-            default -> ((IStringRepresentable) this.wrappedConfig).getStringValue();
-        };
+            case BOOLEAN:       return String.valueOf(((IConfigBoolean) this.wrappedConfig).getBooleanValue());
+            case DOUBLE:        return String.valueOf(((IConfigDouble) this.wrappedConfig).getDoubleValue());
+            case INTEGER:       return String.valueOf(((IConfigInteger) this.wrappedConfig).getIntegerValue());
+            case COLOR:         return String.format("#%08X", ((IConfigInteger) this.wrappedConfig).getIntegerValue());
+            case OPTION_LIST:   return ((IConfigOptionList) this.wrappedConfig).getOptionListValue().getStringValue();
+            case HOTKEY:        return ((IHotkey) this.wrappedConfig).getKeybind().getStringValue();
+            case STRING:
+            default:            return ((IStringRepresentable) this.wrappedConfig).getStringValue();
+        }
     }
 
     @Override
     public String getDefaultStringValue()
     {
-        return switch (this.wrappedType)
+        switch (this.wrappedType)
         {
-            case BOOLEAN -> String.valueOf(((IConfigBoolean) this.wrappedConfig).getDefaultBooleanValue());
-            case DOUBLE -> String.valueOf(((IConfigDouble) this.wrappedConfig).getDefaultDoubleValue());
-            case INTEGER -> String.valueOf(((IConfigInteger) this.wrappedConfig).getDefaultIntegerValue());
-            case COLOR -> String.format("#%08X", ((IConfigInteger) this.wrappedConfig).getDefaultIntegerValue());
-            case OPTION_LIST -> ((IConfigOptionList) this.wrappedConfig).getDefaultOptionListValue().getStringValue();
-            case HOTKEY -> ((IHotkey) this.wrappedConfig).getKeybind().getDefaultStringValue();
-            default -> ((IStringRepresentable) this.wrappedConfig).getDefaultStringValue();
-        };
+            case BOOLEAN:       return String.valueOf(((IConfigBoolean) this.wrappedConfig).getDefaultBooleanValue());
+            case DOUBLE:        return String.valueOf(((IConfigDouble) this.wrappedConfig).getDefaultDoubleValue());
+            case INTEGER:       return String.valueOf(((IConfigInteger) this.wrappedConfig).getDefaultIntegerValue());
+            case COLOR:         return String.format("#%08X", ((IConfigInteger) this.wrappedConfig).getDefaultIntegerValue());
+            case OPTION_LIST:   return ((IConfigOptionList) this.wrappedConfig).getDefaultOptionListValue().getStringValue();
+            case HOTKEY:        return ((IHotkey) this.wrappedConfig).getKeybind().getDefaultStringValue();
+            case STRING:
+            default:            return ((IStringRepresentable) this.wrappedConfig).getDefaultStringValue();
+        }
     }
 
     @Override
@@ -183,55 +185,62 @@ public class ConfigTypeWrapper implements IConfigBoolean, IConfigDouble, IConfig
     @Override
     public boolean isModified()
     {
-        return switch (this.wrappedType)
+        switch (this.wrappedType)
         {
-            case HOTKEY -> ((IHotkey) this.wrappedConfig).getKeybind().isModified();
-            case BOOLEAN ->
+            case HOTKEY:
+                return ((IHotkey) this.wrappedConfig).getKeybind().isModified();
+            case BOOLEAN:
             {
                 IConfigBoolean config = (IConfigBoolean) this.wrappedConfig;
-                yield config.getBooleanValue() != config.getDefaultBooleanValue();
+                return config.getBooleanValue() != config.getDefaultBooleanValue();
             }
-            case DOUBLE ->
+            case DOUBLE:
             {
                 IConfigDouble config = (IConfigDouble) this.wrappedConfig;
-                yield config.getDoubleValue() != config.getDefaultDoubleValue();
+                return config.getDoubleValue() != config.getDefaultDoubleValue();
             }
-            case INTEGER, COLOR ->
+            case INTEGER:
+            case COLOR:
             {
                 IConfigInteger config = (IConfigInteger) this.wrappedConfig;
-                yield config.getIntegerValue() != config.getDefaultIntegerValue();
+                return config.getIntegerValue() != config.getDefaultIntegerValue();
             }
-            case OPTION_LIST ->
+            case OPTION_LIST:
             {
                 IConfigOptionList config = (IConfigOptionList) this.wrappedConfig;
-                yield config.getOptionListValue() != config.getDefaultOptionListValue();
+                return config.getOptionListValue() != config.getDefaultOptionListValue();
             }
-            case STRING ->
+            case STRING:
             {
                 IStringRepresentable config = (IStringRepresentable) this.wrappedConfig;
-                yield config.getStringValue().equals(config.getDefaultStringValue()) == false;
+                return config.getStringValue().equals(config.getDefaultStringValue()) == false;
             }
-            default -> false;
-        };
+            default:
+                return false;
+        }
     }
 
     @Override
     public boolean isModified(String newValue)
     {
-        return switch (this.wrappedType)
+        switch (this.wrappedType)
         {
-            case HOTKEY -> ((IHotkey) this.wrappedConfig).getKeybind().isModified(newValue);
-            case BOOLEAN ->
-                    String.valueOf(((IConfigBoolean) this.wrappedConfig).getBooleanValue()).equals(newValue) == false;
-            case DOUBLE ->
-                    String.valueOf(((IConfigDouble) this.wrappedConfig).getDoubleValue()).equals(newValue) == false;
-            case INTEGER ->
-                    String.valueOf(((IConfigInteger) this.wrappedConfig).getIntegerValue()).equals(newValue) == false;
-            case COLOR -> ((ConfigColor) this.wrappedConfig).getStringValue().equals(newValue) == false;
-            case OPTION_LIST ->
-                    ((IConfigOptionList) this.wrappedConfig).getOptionListValue().getStringValue().equals(newValue) == false;
-            default -> ((IStringRepresentable) this.wrappedConfig).getStringValue().equals(newValue) == false;
-        };
+            case HOTKEY:
+                return ((IHotkey) this.wrappedConfig).getKeybind().isModified(newValue);
+            case BOOLEAN:
+                return String.valueOf(((IConfigBoolean) this.wrappedConfig).getBooleanValue()).equals(newValue) == false;
+            case DOUBLE:
+                return String.valueOf(((IConfigDouble) this.wrappedConfig).getDoubleValue()).equals(newValue) == false;
+            case INTEGER:
+                return String.valueOf(((IConfigInteger) this.wrappedConfig).getIntegerValue()).equals(newValue) == false;
+            case COLOR:
+                return ((ConfigColor) this.wrappedConfig).getStringValue().equals(newValue) == false;
+            case OPTION_LIST:
+                return ((IConfigOptionList) this.wrappedConfig).getOptionListValue().getStringValue().equals(newValue) == false;
+            case STRING:
+            default:
+                return ((IStringRepresentable) this.wrappedConfig).getStringValue().equals(newValue) == false;
+        }
     }
 
     @Override
@@ -439,17 +448,24 @@ public class ConfigTypeWrapper implements IConfigBoolean, IConfigDouble, IConfig
     @Override
     public JsonElement getAsJsonElement()
     {
-        return switch (this.wrappedType)
+        switch (this.wrappedType)
         {
-            case BOOLEAN -> new JsonPrimitive(((IConfigBoolean) this.wrappedConfig).getBooleanValue());
-            case DOUBLE -> new JsonPrimitive(((IConfigDouble) this.wrappedConfig).getDoubleValue());
-            case INTEGER -> new JsonPrimitive(((IConfigInteger) this.wrappedConfig).getIntegerValue());
-            case STRING -> new JsonPrimitive(((IConfigValue) this.wrappedConfig).getStringValue());
-            case COLOR -> new JsonPrimitive(((IConfigInteger) this.wrappedConfig).getStringValue());
-            case OPTION_LIST ->
-                    new JsonPrimitive(((IConfigOptionList) this.wrappedConfig).getOptionListValue().getStringValue());
-            case HOTKEY -> ((IHotkey) this.wrappedConfig).getAsJsonElement();
-            default -> new JsonPrimitive(this.getStringValue());
-        };
+            case BOOLEAN:
+                return new JsonPrimitive(((IConfigBoolean) this.wrappedConfig).getBooleanValue());
+            case DOUBLE:
+                return new JsonPrimitive(((IConfigDouble) this.wrappedConfig).getDoubleValue());
+            case INTEGER:
+                return new JsonPrimitive(((IConfigInteger) this.wrappedConfig).getIntegerValue());
+            case STRING:
+                return new JsonPrimitive(((IConfigValue) this.wrappedConfig).getStringValue());
+            case COLOR:
+                return new JsonPrimitive(((IConfigInteger) this.wrappedConfig).getStringValue());
+            case OPTION_LIST:
+                return new JsonPrimitive(((IConfigOptionList) this.wrappedConfig).getOptionListValue().getStringValue());
+            case HOTKEY:
+                return ((IHotkey) this.wrappedConfig).getAsJsonElement();
+            default:
+                return new JsonPrimitive(this.getStringValue());
+        }
     }
 }


### PR DESCRIPTION
It's just a rollback, there's no need for destructive changes