### PR TITLE
Fix memory leaks in RenderUtils.java

### DIFF
--- a/src/main/java/fi/dy/masa/malilib/render/RenderUtils.java
+++ b/src/main/java/fi/dy/masa/malilib/render/RenderUtils.java
@@ -1008,24 +1008,28 @@ public class RenderUtils
         Matrix4f modelMatrix = new Matrix4f();
         modelMatrix.identity();
 
+        BufferAllocator allocator = new BufferAllocator(RenderLayer.DEFAULT_BUFFER_SIZE);
+
         for (String line : text)
         {
             if (disableDepth)
             {
                 //RenderSystem.depthMask(false);
                 RenderSystem.disableDepthTest();
-                VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(new BufferAllocator(RenderLayer.DEFAULT_BUFFER_SIZE));
+                VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(allocator);
                 textRenderer.draw(line, -strLenHalf, textY, 0x20000000 | (textColor & 0xFFFFFF), false, modelMatrix, immediate, TextRenderer.TextLayerType.SEE_THROUGH, 0, 15728880);
                 immediate.draw();
                 RenderSystem.enableDepthTest();
                 //RenderSystem.depthMask(true);
             }
 
-            VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(new BufferAllocator(RenderLayer.DEFAULT_BUFFER_SIZE));
+            VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(allocator);
             textRenderer.draw(line, -strLenHalf, textY, textColor, false, modelMatrix, immediate, TextRenderer.TextLayerType.SEE_THROUGH, 0, 15728880);
             immediate.draw();
             textY += textRenderer.fontHeight;
         }
+
+        allocator.close();
 
         if (disableDepth == false)
         {
@@ -1334,7 +1338,8 @@ public class RenderUtils
                 x1 += 8;
                 y1 += 8;
                 z = 310;
-                VertexConsumerProvider.Immediate consumer = VertexConsumerProvider.immediate(new BufferAllocator(RenderLayer.DEFAULT_BUFFER_SIZE));
+                BufferAllocator allocator = new BufferAllocator(RenderLayer.DEFAULT_BUFFER_SIZE);
+                VertexConsumerProvider.Immediate consumer = VertexConsumerProvider.immediate(allocator);
                 double scale = (double) (dimensions - 16) / 128.0D;
 
                 MatrixStack matrixStack = new MatrixStack();
@@ -1347,6 +1352,7 @@ public class RenderUtils
                 mc().getMapRenderer().draw(mapRenderState, matrixStack, consumer, false, uv);
                 consumer.draw();
                 matrixStack.pop();
+                allocator.close();
             }
 
             //RenderSystem.disableDepthTest();


### PR DESCRIPTION
Fixes https://github.com/sakura-ryoko/minihud/issues/97.

As I said in the MiniHUD issue, I am not a Java dev by background. So I have made these changes locally by checking out the 1.21.4-0.23.2-sakura.6 and making them in there. I have tested them in that tag and they work for me for the villager overlay. I have then simply made the changes again in the 1.21.4 branch - I don't see how it would clash with changes you made but I will let you be the judge of them.

I noticed the same apparent issue in the map preview code and fixed it proactively. It seems to be called in MiniHUD, but I have not tested that particular functionality.

It might be even more efficient to pass in the allocator, but I am not inclined to look at all mods you've built and look for code that calls these methods to refactor all of it. :)

Let me know if you would like me to rebase or whatever!