### PR TITLE
Add automatic publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,35 +4,35 @@
 # against bad commits.
 
 name: build
-on: [ pull_request, push ]
+on: [pull_request, push]
 
 jobs:
   build:
-    strategy:
-      matrix:
-        # Use these Java versions
-        java: [ 21 ]
-        distro: [ temurin ]
-        # and run on both Linux and Windows
-        os: [ ubuntu-latest ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
       - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v3
-      - name: setup jdk ${{ matrix.java }}
+        uses: gradle/actions/wrapper-validation@v4
+      - name: setup jdk
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ matrix.distro }}
-          java-version: ${{ matrix.java }}
+          java-version: '21'
+          distribution: 'temurin'
+      - name: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: make gradle wrapper executable
-        if: ${{ runner.os != 'Windows' }}
         run: chmod +x ./gradlew
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' }}
         uses: actions/upload-artifact@v4
         with:
           name: Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: release
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Your release tag'
+        required: true
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+      - name: validate gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+      - name: setup jdk
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: get tag
+        run: |
+          if [ "${{ github.event_name }}" == "release" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          else
+            echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+          fi
+      - name: get release info
+        id: getByTag
+        uses: cardinalby/git-get-release-action@1.2.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ env.tag }}
+      - name: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: make gradle wrapper executable
+        run: chmod +x ./gradlew
+      - name: build and publish
+        run: ./gradlew build tryPublishMods
+        env:
+          CHANGELOG: ${{ steps.getByTag.outputs.body }}
+#          MODRINTH_API_KEY: ${{ secrets.MODRINTH_API_KEY }}
+#          CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
+      - name: publish to github
+        uses: Kir-Antipov/mc-publish@v3.3
+        with:
+          github-tag: ${{ env.tag }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            build/libs/!(*-@(shadow|sources)).jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         run: ./gradlew build tryPublishMods
         env:
           CHANGELOG: ${{ steps.getByTag.outputs.body }}
-#          MODRINTH_API_KEY: ${{ secrets.MODRINTH_API_KEY }}
+          MODRINTH_API_KEY: ${{ secrets.MODRINTH_API_KEY }}
 #          CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
       - name: publish to github
         uses: Kir-Antipov/mc-publish@v3.3

--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,7 @@ tasks.register("tryPublishMods") {
 	}
 }
 
+// https://modmuss50.github.io/mod-publish-plugin/
 publishMods {
 	final boolean debug = providers.environmentVariable("MODRINTH_API_KEY").orNull == null
 
@@ -134,9 +135,9 @@ publishMods {
 		accessToken = providers.environmentVariable("MODRINTH_API_KEY")
 		projectId = "GcWjdA9I"
 		minecraftVersionRange {
-			final List<String> range = List.of(minecraft_version_range.toString().split("-"))
-			start = range.getFirst()
-			end = range.getLast()
+			final String[] range = minecraft_version_range.toString().split("-")
+			start = range.first()
+			end = range.last()
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'fabric-loom' version '1.10-SNAPSHOT'
+	id 'me.modmuss50.mod-publish-plugin' version '0.8.4'
 	id 'maven-publish'
 }
 
@@ -106,6 +107,37 @@ java {
 jar {
 	from("LICENSE") {
 		rename { "${it}_${base.archivesName}"}
+	}
+}
+
+tasks.register("tryPublishMods") {
+	// Skip the version ending in -sakura.x
+	if (mod_version.matches(".+-sakura\\.\\d+")) {
+		println "Skip publishMods"
+	} else {
+		finalizedBy("publishMods")
+	}
+}
+
+publishMods {
+	final boolean debug = providers.environmentVariable("MODRINTH_API_KEY").orNull == null
+
+	dryRun = debug
+	file = tasks.remapJar.archiveFile
+	displayName = "${mod_name} ${minecraft_version}-${mod_version}"
+	version = "${mod_version}"
+	changelog = debug ? "# Test" : providers.environmentVariable("CHANGELOG").toString()
+	modLoaders.add("fabric")
+	type = release_type == "alpha" ? ALPHA : release_type == "beta" ? BETA : STABLE
+
+	modrinth {
+		accessToken = providers.environmentVariable("MODRINTH_API_KEY")
+		projectId = "GcWjdA9I"
+		minecraftVersionRange {
+			final List<String> range = List.of(minecraft_version_range.toString().split("-"))
+			start = range.getFirst()
+			end = range.getLast()
+		}
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,7 @@ fabric_loader_version = 0.16.14
 mod_menu_version = 14.0.0-rc.2
 iris_version = 1.8.11
 fabric_api_version = 0.119.6+1.21.5
+
+# Release
+release_type = stable
+minecraft_version_range = 1.21.5


### PR DESCRIPTION
## Features

When publishing a release, the mod can be automatically published to platforms like GitHub and Modrinth.

If the version ends with `-sakura.x`, it will only be published to GitHub.

You can also manually push by specifying the release tag.

## Settings

Set `release_type` and `minecraft_version_range` in `gradle.properties`.

The `release_type` field accepts `stable`, `beta`, or `alpha` to specify the release channel.

The `minecraft_version_range` field specifies the supported Minecraft versions. Here are some examples:

- Only 1.21.5 is supported. You can set it to `1.21.5`
- All versions from 1.21 to 1.21.5 are supported. You can specify the range as `1.21-1.21.5`

You also need to set `MODRINTH_API_KEY` with your Modrinth [PAT](https://modrinth.com/settings/pats), which requires the following permissions:

- `Create versions`
- `Read versions`
- `Write versions`

## Other

I have only configured publishing to Modrinth. If you need to publish to CurseForge and Discord, you can follow the documentation to add the required settings.

Publishing plugin documentation: [https://modmuss50.github.io/mod-publish-plugin/](https://modmuss50.github.io/mod-publish-plugin/)

I've also added GitHub Actions cache to speed up the build process.