### PR TITLE
Fix VillagerTradesDisplay with servux

### DIFF
--- a/src/main/java/fi/dy/masa/malilib/render/InventoryOverlayScreen.java
+++ b/src/main/java/fi/dy/masa/malilib/render/InventoryOverlayScreen.java
@@ -228,7 +228,7 @@ public class InventoryOverlayScreen extends Screen implements Renderable
 
 			// Villager Trades Display
 			if (type == InventoryOverlayType.VILLAGER &&
-				this.previewData.data() != null && this.previewData.data().contains(NbtKeys.OFFERS, Constants.NBT.TAG_LIST))
+				this.previewData.data() != null && this.previewData.data().contains(NbtKeys.OFFERS, Constants.NBT.TAG_COMPOUND))
 			{
 				NonNullList<@NotNull ItemStack> offers = InventoryUtils.getSellingItemsFromData(this.previewData.data(), world.registryAccess());
 				Container tradeOffers = InventoryUtils.getAsInventory(offers);


### PR DESCRIPTION
*This PR may also be applicable to other versions.
```
{
  Offers:{
    Recipes:[...]
  }
}
```
In villager's NBT, `Offers`is a compound not a list.

