### PR TITLE
Refactor Config Option Button Generation for Enhanced Extensibility

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https://mirrors.cloud.tencent.com/gradle/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
-distributionUrl=https://mirrors.cloud.tencent.com/gradle/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/fi/dy/masa/malilib/config/IConfigBase.java
+++ b/src/main/java/fi/dy/masa/malilib/config/IConfigBase.java
@@ -3,6 +3,7 @@ package fi.dy.masa.malilib.config;
 import java.util.Locale;
 import javax.annotation.Nullable;
 import com.google.gson.JsonElement;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
 
 public interface IConfigBase
 {
@@ -118,4 +119,9 @@ public interface IConfigBase
      * @return ()
      */
     JsonElement getAsJsonElement();
+	
+	/**
+	 * Customize config option buttons
+	 */
+	void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption);
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/BooleanHotkeyGuiWrapper.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/BooleanHotkeyGuiWrapper.java
@@ -2,14 +2,15 @@ package fi.dy.masa.malilib.config.options;
 
 import javax.annotation.Nullable;
 
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
-import fi.dy.masa.malilib.config.IConfigBoolean;
-import fi.dy.masa.malilib.config.IHotkeyTogglable;
 import fi.dy.masa.malilib.hotkeys.IKeybind;
 import fi.dy.masa.malilib.hotkeys.KeybindMulti;
 import fi.dy.masa.malilib.hotkeys.KeybindSettings;
@@ -197,4 +198,36 @@ public class BooleanHotkeyGuiWrapper extends ConfigBoolean implements IHotkeyTog
     {
         this.lastBooleanHotkey = Pair.of(this.booleanConfig.getBooleanValue(), this.keybind.getStringValue());
     }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+		
+		y += 1;
+		
+		String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+		
+		IConfigBoolean booleanConfig = getBooleanConfig();
+		IKeybind keybind = getKeybind();
+		configOption.addBooleanAndHotkeyWidgets(x, y, configWidth, this, booleanConfig, keybind);
+	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigBlockState.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigBlockState.java
@@ -5,6 +5,14 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.MaLiLibIcons;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.interfaces.IGuiIcon;
+import fi.dy.masa.malilib.gui.widgets.WidgetBlockStateIcon;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
+import fi.dy.masa.malilib.gui.wrappers.TextFieldType;
 import org.jetbrains.annotations.ApiStatus;
 
 import com.mojang.serialization.Codec;
@@ -12,12 +20,9 @@ import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.commands.arguments.blocks.BlockStateParser;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigBlockState;
 import fi.dy.masa.malilib.util.StringUtils;
 import fi.dy.masa.malilib.util.game.BlockUtils;
 
@@ -185,5 +190,51 @@ public class ConfigBlockState extends ConfigBase<ConfigBlockState> implements IC
 	public JsonElement getAsJsonElement()
 	{
 		return BlockState.CODEC.encodeStart(JsonOps.INSTANCE, this.value).result().orElse(new JsonObject());
+	}
+	
+	@Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+		
+		y += 1;
+		int configHeight = 20;
+		
+		String configName = getConfigGuiDisplayName();
+		
+		configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+		
+		String comment;
+		IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+		
+		if (infoProvider != null)
+		{
+			comment = infoProvider.getHoverInfo(this);
+		}
+		else
+		{
+			comment = getComment();
+		}
+		
+		if (comment != null)
+		{
+			configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+		}
+		
+		x += labelWidth + 10;
+		
+		int resetX = x + configWidth + 2;
+		
+		configWidth -= 22; // adjust the width to match other configs due to the block icon display
+		configOption.colorDisplayPosX = x + configWidth + 2;
+		configOption.addWidget(new WidgetBlockStateIcon(configOption.colorDisplayPosX, y + 1, 18, 18, this));
+		
+		TextFieldType.STRING.setMaxLength(configOption.maxTextfieldTextLength);
+		
+		configOption.addConfigTextFieldEntry(x, y, resetX, configWidth, configHeight, this, TextFieldType.BLOCK_STATE);
+		
+		if (this instanceof IConfigSlider)
+		{
+			IGuiIcon icon = ((IConfigSlider) this).shouldUseSlider() ? MaLiLibIcons.BTN_TXTFIELD : MaLiLibIcons.BTN_SLIDER;
+			ButtonGeneric toggleBtn = new ButtonGeneric(configOption.colorDisplayPosX, y + 2, icon);
+			configOption.addButton(toggleBtn, new WidgetConfigOption.ListenerSliderToggle((IConfigSlider) this));
+		}
 	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigBoolean.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigBoolean.java
@@ -8,8 +8,10 @@ import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigBoolean;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
 import fi.dy.masa.malilib.util.StringUtils;
 
 public class ConfigBoolean extends ConfigBase<ConfigBoolean> implements IConfigBoolean
@@ -181,5 +183,37 @@ public class ConfigBoolean extends ConfigBase<ConfigBoolean> implements IConfigB
     public JsonElement getAsJsonElement()
     {
         return new JsonPrimitive(this.value);
+    }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+		
+		y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+        
+        ConfigButtonBoolean optionButton = new ConfigButtonBoolean(x, y, configWidth, configHeight, this);
+        configOption.addConfigButtonEntry(x + configWidth + 2, y, this, optionButton);
     }
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigBooleanHotkeyed.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigBooleanHotkeyed.java
@@ -2,6 +2,10 @@ package fi.dy.masa.malilib.config.options;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
+import fi.dy.masa.malilib.hotkeys.*;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.mojang.serialization.Codec;
@@ -9,11 +13,6 @@ import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.IHotkeyTogglable;
-import fi.dy.masa.malilib.hotkeys.IKeybind;
-import fi.dy.masa.malilib.hotkeys.KeyCallbackToggleBooleanConfigWithMessage;
-import fi.dy.masa.malilib.hotkeys.KeybindMulti;
-import fi.dy.masa.malilib.hotkeys.KeybindSettings;
 import fi.dy.masa.malilib.util.data.json.JsonUtils;
 import fi.dy.masa.malilib.util.StringUtils;
 
@@ -255,4 +254,35 @@ public class ConfigBooleanHotkeyed extends ConfigBoolean implements IHotkeyToggl
         obj.add("hotkey", this.getKeybind().getAsJsonElement());
         return obj;
     }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+		
+		y += 1;
+		
+		String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+		
+		IKeybind keybind = this.getKeybind();
+		configOption.addBooleanAndHotkeyWidgets(x, y, configWidth, this, this, keybind);
+	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigColor.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigColor.java
@@ -8,8 +8,11 @@ import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigColor;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetColorIndicator;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
+import fi.dy.masa.malilib.gui.wrappers.TextFieldType;
 import fi.dy.masa.malilib.util.MathUtils;
 import fi.dy.masa.malilib.util.StringUtils;
 import fi.dy.masa.malilib.util.data.Color4f;
@@ -265,4 +268,46 @@ public class ConfigColor extends ConfigBase<ConfigColor> implements IConfigColor
     {
         return new JsonPrimitive(this.getStringValue());
     }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+        
+        final ConfigType type = ConfigType.COLOR;
+        
+        y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+		
+		int resetX = x + configWidth + 2;
+		
+		configWidth -= 22; // adjust the width to match other configs due to the color display
+		configOption.colorDisplayPosX = x + configWidth + 2;
+		configOption.addWidget(new WidgetColorIndicator(configOption.colorDisplayPosX, y + 1, 18, 18, this));
+		
+		TextFieldType textType = TextFieldType.STRING.setMaxLength(12);
+		
+		configOption.addConfigTextFieldEntry(x, y, resetX, configWidth, configHeight, this, textType);
+		
+	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigColorList.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigColorList.java
@@ -12,8 +12,10 @@ import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigColorList;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
 import fi.dy.masa.malilib.util.StringUtils;
 import fi.dy.masa.malilib.util.data.Color4f;
 import fi.dy.masa.malilib.util.data.ImmutableCopy;
@@ -183,4 +185,38 @@ public class ConfigColorList extends ConfigBase<ConfigColorList> implements ICon
             MaLiLib.LOGGER.warn("Failed to set config value for '{}' from the JSON element '{}'", this.getName(), element, e);
         }
     }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+        
+        final ConfigType type = ConfigType.COLOR_LIST;
+        
+        y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+		
+		ConfigButtonColorList optionButton = new ConfigButtonColorList(x, y, configWidth, configHeight, this, configOption.host, configOption.host.getDialogHandler());
+		configOption.addConfigButtonEntry(x + configWidth + 2, y, this, optionButton);
+	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigDouble.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigDouble.java
@@ -8,8 +8,13 @@ import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigDouble;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.MaLiLibIcons;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.interfaces.IGuiIcon;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
+import fi.dy.masa.malilib.gui.wrappers.TextFieldType;
 import fi.dy.masa.malilib.util.MathUtils;
 import fi.dy.masa.malilib.util.StringUtils;
 
@@ -266,4 +271,55 @@ public class ConfigDouble extends ConfigBase<ConfigDouble> implements IConfigDou
     {
         return new JsonPrimitive(this.value);
     }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+        
+        final ConfigType type = ConfigType.DOUBLE;
+        
+        y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+		
+		int resetX = x + configWidth + 2;
+		
+		configWidth -= 18;
+		configOption.colorDisplayPosX = x + configWidth + 2;
+		
+		if (this.shouldUseSlider())
+		{
+			configOption.addConfigSliderEntry(x, y, resetX, configWidth, configHeight, this);
+		}
+		else
+		{
+			TextFieldType.STRING.setMaxLength(configOption.maxTextfieldTextLength);
+			
+			configOption.addConfigTextFieldEntry(x, y, resetX, configWidth, configHeight, this, TextFieldType.DOUBLE);
+		}
+		
+		IGuiIcon icon = this.shouldUseSlider() ? MaLiLibIcons.BTN_TXTFIELD : MaLiLibIcons.BTN_SLIDER;
+		ButtonGeneric toggleBtn = new ButtonGeneric(configOption.colorDisplayPosX, y + 2, icon);
+		configOption.addButton(toggleBtn, new WidgetConfigOption.ListenerSliderToggle(this));
+	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigFloat.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigFloat.java
@@ -8,8 +8,13 @@ import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigFloat;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.MaLiLibIcons;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.interfaces.IGuiIcon;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
+import fi.dy.masa.malilib.gui.wrappers.TextFieldType;
 import fi.dy.masa.malilib.util.MathUtils;
 import fi.dy.masa.malilib.util.StringUtils;
 
@@ -261,4 +266,54 @@ public class ConfigFloat extends ConfigBase<ConfigFloat> implements IConfigFloat
     {
         return new JsonPrimitive(this.value);
     }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+        
+        final ConfigType type = ConfigType.FLOAT;
+        
+        y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+		
+		int resetX = x + configWidth + 2;
+		
+		configWidth -= 18;
+		configOption.colorDisplayPosX = x + configWidth + 2;
+		
+		if (this.shouldUseSlider())
+		{
+			configOption.addConfigSliderEntry(x, y, resetX, configWidth, configHeight, this);
+		}
+		else
+		{
+			TextFieldType.STRING.setMaxLength(configOption.maxTextfieldTextLength);
+			configOption.addConfigTextFieldEntry(x, y, resetX, configWidth, configHeight, this, TextFieldType.FLOAT);
+		}
+		
+		IGuiIcon icon = this.shouldUseSlider() ? MaLiLibIcons.BTN_TXTFIELD : MaLiLibIcons.BTN_SLIDER;
+		ButtonGeneric toggleBtn = new ButtonGeneric(configOption.colorDisplayPosX, y + 2, icon);
+		configOption.addButton(toggleBtn, new WidgetConfigOption.ListenerSliderToggle(this));
+	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigHotkey.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigHotkey.java
@@ -8,8 +8,9 @@ import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigHotkey;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
 import fi.dy.masa.malilib.hotkeys.IHotkey;
 import fi.dy.masa.malilib.hotkeys.IKeybind;
 import fi.dy.masa.malilib.hotkeys.KeybindMulti;
@@ -233,5 +234,35 @@ public class ConfigHotkey extends ConfigBase<ConfigHotkey> implements IHotkey, I
 	public JsonElement getAsJsonElement()
 	{
 		return this.keybind.getAsJsonElement();
+	}
+	
+	@Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+		
+		y += 1;
+		
+		String configName = getConfigGuiDisplayName();
+		
+		configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+		
+		String comment;
+		IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+		
+		if (infoProvider != null)
+		{
+			comment = infoProvider.getHoverInfo(this);
+		}
+		else
+		{
+			comment = getComment();
+		}
+		
+		if (comment != null)
+		{
+			configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+		}
+		
+		x += labelWidth + 10;
+		
+		configOption.addHotkeyConfigElements(x, y, configWidth, getName(), this);
 	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigInteger.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigInteger.java
@@ -8,8 +8,13 @@ import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigInteger;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.MaLiLibIcons;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.interfaces.IGuiIcon;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
+import fi.dy.masa.malilib.gui.wrappers.TextFieldType;
 import fi.dy.masa.malilib.util.MathUtils;
 import fi.dy.masa.malilib.util.StringUtils;
 
@@ -269,4 +274,52 @@ public class ConfigInteger extends ConfigBase<ConfigInteger> implements IConfigI
     {
         return new JsonPrimitive(this.value);
     }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+		
+		y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+		
+		int resetX = x + configWidth + 2;
+		
+		configWidth -= 18;
+		configOption.colorDisplayPosX = x + configWidth + 2;
+		
+		if (this.shouldUseSlider())
+		{
+			configOption.addConfigSliderEntry(x, y, resetX, configWidth, configHeight, this);
+		}
+		else
+		{
+			TextFieldType.STRING.setMaxLength(configOption.maxTextfieldTextLength);
+			configOption.addConfigTextFieldEntry(x, y, resetX, configWidth, configHeight, this, TextFieldType.INTEGER);
+		}
+		
+		IGuiIcon icon = this.shouldUseSlider() ? MaLiLibIcons.BTN_TXTFIELD : MaLiLibIcons.BTN_SLIDER;
+		ButtonGeneric toggleBtn = new ButtonGeneric(configOption.colorDisplayPosX, y + 2, icon);
+		configOption.addButton(toggleBtn, new WidgetConfigOption.ListenerSliderToggle(this));
+	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigLockedList.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigLockedList.java
@@ -10,6 +10,9 @@ import com.google.gson.JsonPrimitive;
 
 import fi.dy.masa.malilib.MaLiLib;
 import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
 import fi.dy.masa.malilib.util.StringUtils;
 import fi.dy.masa.malilib.util.data.ImmutableCopy;
 
@@ -254,4 +257,36 @@ public class ConfigLockedList extends ConfigBase<ConfigLockedList> implements IC
             MaLiLib.LOGGER.warn("Failed to set config value for '{}' from the JSON element '{}'", this.getName(), element, e);
         }
     }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+		
+		y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+		
+		ConfigButtonLockedList optionButton = new ConfigButtonLockedList(x, y, configWidth, configHeight, this, configOption.host, configOption.host.getDialogHandler());
+		configOption.addConfigButtonEntry(x + configWidth + 2, y, this, optionButton);
+	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigOptionList.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigOptionList.java
@@ -4,10 +4,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigOptionList;
-import fi.dy.masa.malilib.config.IConfigOptionListEntry;
-import fi.dy.masa.malilib.config.IStringRepresentable;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
 import fi.dy.masa.malilib.util.StringUtils;
 
 public class ConfigOptionList extends ConfigBase<ConfigOptionList> implements IConfigOptionList, IStringRepresentable
@@ -182,5 +182,37 @@ public class ConfigOptionList extends ConfigBase<ConfigOptionList> implements IC
     public JsonElement getAsJsonElement()
     {
         return new JsonPrimitive(this.getStringValue());
+    }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+		
+		y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+		
+        ConfigButtonOptionList optionButton = new ConfigButtonOptionList(x, y, configWidth, configHeight, this);
+        configOption.addConfigButtonEntry(x + configWidth + 2, y, this, optionButton);
     }
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigOptionValues.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigOptionValues.java
@@ -8,11 +8,12 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigOptionValues;
-import fi.dy.masa.malilib.config.IStringRepresentable;
+import fi.dy.masa.malilib.config.*;
 import fi.dy.masa.malilib.config.value.BaseOptionListConfigValue;
 import fi.dy.masa.malilib.config.value.OptionListConfigValue;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
 import fi.dy.masa.malilib.util.ListUtils;
 import fi.dy.masa.malilib.util.StringUtils;
 import fi.dy.masa.malilib.util.data.ImmutableCopy;
@@ -249,5 +250,39 @@ public class ConfigOptionValues<T extends OptionListConfigValue> extends ConfigB
 	public JsonElement getAsJsonElement()
 	{
 		return new JsonPrimitive(this.getStringValue());
+	}
+	
+	@Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+		
+		final ConfigType type = ConfigType.OPTION_VALUES;
+		
+		y += 1;
+		int configHeight = 20;
+		
+		String configName = getConfigGuiDisplayName();
+		
+		configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+		
+		String comment;
+		IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+		
+		if (infoProvider != null)
+		{
+			comment = infoProvider.getHoverInfo(this);
+		}
+		else
+		{
+			comment = getComment();
+		}
+		
+		if (comment != null)
+		{
+			configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+		}
+		
+		x += labelWidth + 10;
+		
+		ConfigButtonOptionValues optionButton = new ConfigButtonOptionValues(x, y, configWidth, configHeight, this);
+		configOption.addConfigButtonEntry(x + configWidth + 2, y, this, optionButton);
 	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigString.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigString.java
@@ -7,9 +7,13 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigString;
-import fi.dy.masa.malilib.config.IConfigValue;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.MaLiLibIcons;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.interfaces.IGuiIcon;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
+import fi.dy.masa.malilib.gui.wrappers.TextFieldType;
 import fi.dy.masa.malilib.util.StringUtils;
 
 public class ConfigString extends ConfigBase<ConfigString> implements IConfigValue, IConfigString
@@ -163,4 +167,48 @@ public class ConfigString extends ConfigBase<ConfigString> implements IConfigVal
     {
         return new JsonPrimitive(this.value);
     }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+        
+        final ConfigType type = ConfigType.STRING;
+        
+        y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+		
+		int resetX = x + configWidth + 2;
+		
+		TextFieldType textType = TextFieldType.STRING.setMaxLength(configOption.maxTextfieldTextLength);
+		
+		configOption.addConfigTextFieldEntry(x, y, resetX, configWidth, configHeight, this, textType);
+		
+		if (this instanceof IConfigSlider)
+		{
+			IGuiIcon icon = ((IConfigSlider) this).shouldUseSlider() ? MaLiLibIcons.BTN_TXTFIELD : MaLiLibIcons.BTN_SLIDER;
+			ButtonGeneric toggleBtn = new ButtonGeneric(configOption.colorDisplayPosX, y + 2, icon);
+			configOption.addButton(toggleBtn, new WidgetConfigOption.ListenerSliderToggle((IConfigSlider) this));
+		}
+	}
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigStringList.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigStringList.java
@@ -2,6 +2,11 @@ package fi.dy.masa.malilib.config.options;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
 import net.minecraft.util.ExtraCodecs;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonArray;
@@ -13,8 +18,6 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.PrimitiveCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigStringList;
 import fi.dy.masa.malilib.util.StringUtils;
 import fi.dy.masa.malilib.util.data.ImmutableCopy;
 
@@ -186,5 +189,37 @@ public class ConfigStringList extends ConfigBase<ConfigStringList> implements IC
         {
             MaLiLib.LOGGER.warn("Failed to set config value for '{}' from the JSON element '{}'", this.getName(), element, e);
         }
+    }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+		
+		y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+        
+        ConfigButtonStringList optionButton = new ConfigButtonStringList(x, y, configWidth, configHeight, this, configOption.host, configOption.host.getDialogHandler());
+        configOption.addConfigButtonEntry(x + configWidth + 2, y, this, optionButton);
     }
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/ConfigTypeWrapper.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/ConfigTypeWrapper.java
@@ -3,12 +3,19 @@ package fi.dy.masa.malilib.config.options;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 
+import fi.dy.masa.malilib.gui.MaLiLibIcons;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.interfaces.IGuiIcon;
+import fi.dy.masa.malilib.gui.widgets.WidgetBlockStateIcon;
+import fi.dy.masa.malilib.gui.widgets.WidgetColorIndicator;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
+import fi.dy.masa.malilib.gui.wrappers.TextFieldType;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
 import fi.dy.masa.malilib.MaLiLib;
 import fi.dy.masa.malilib.config.*;
-import fi.dy.masa.malilib.config.value.OptionListConfigValue;
 import fi.dy.masa.malilib.hotkeys.IHotkey;
 import fi.dy.masa.malilib.hotkeys.IKeybind;
 import fi.dy.masa.malilib.interfaces.IValueChangeCallback;
@@ -882,5 +889,143 @@ public class ConfigTypeWrapper implements IConfigBoolean, IConfigColor, IConfigD
             case BLOCK_STATE -> ((ConfigBlockState) this.wrappedConfig).getAsJsonElement();
             default -> new JsonPrimitive(this.getStringValue());
         };
+    }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+        
+        final ConfigType type = getType();
+        
+        y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+        
+        if (type == ConfigType.BOOLEAN)
+        {
+            ConfigButtonBoolean optionButton = new ConfigButtonBoolean(x, y, configWidth, configHeight, (IConfigBoolean) this);
+            configOption.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) this, optionButton);
+        }
+        else if (type == ConfigType.OPTION_LIST)
+        {
+            ConfigButtonOptionList optionButton = new ConfigButtonOptionList(x, y, configWidth, configHeight, (IConfigOptionList) this);
+            configOption.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) this, optionButton);
+        }
+        else if (type == ConfigType.OPTION_VALUES)
+        {
+            ConfigButtonOptionValues optionButton = new ConfigButtonOptionValues(x, y, configWidth, configHeight, (IConfigOptionValues<?>) this);
+            configOption.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) this, optionButton);
+        }
+        else if (type == ConfigType.STRING_LIST)
+        {
+            ConfigButtonStringList optionButton = new ConfigButtonStringList(x, y, configWidth, configHeight, (IConfigStringList) this, configOption.host, configOption.host.getDialogHandler());
+            configOption.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) this, optionButton);
+        }
+        else if (type == ConfigType.LOCKED_LIST)
+        {
+            ConfigButtonLockedList optionButton = new ConfigButtonLockedList(x, y, configWidth, configHeight, (IConfigLockedList) this, configOption.host, configOption.host.getDialogHandler());
+            configOption.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) this, optionButton);
+        }
+        else if (type == ConfigType.COLOR_LIST)
+        {
+            ConfigButtonColorList optionButton = new ConfigButtonColorList(x, y, configWidth, configHeight, (IConfigColorList) this, configOption.host, configOption.host.getDialogHandler());
+            configOption.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) this, optionButton);
+        }
+        else if (type == ConfigType.HOTKEY)
+        {
+            configOption.addHotkeyConfigElements(x, y, configWidth, getName(), (IHotkey) this);
+        }
+        else if (type == ConfigType.STRING ||
+            type == ConfigType.COLOR ||
+            type == ConfigType.INTEGER ||
+            type == ConfigType.DOUBLE ||
+            type == ConfigType.FLOAT ||
+            type == ConfigType.BLOCK_STATE)
+        {
+            int resetX = x + configWidth + 2;
+            
+            if (type == ConfigType.COLOR)
+            {
+                configWidth -= 22; // adjust the width to match other configs due to the color display
+                configOption.colorDisplayPosX = x + configWidth + 2;
+                configOption.addWidget(new WidgetColorIndicator(configOption.colorDisplayPosX, y + 1, 18, 18, (IConfigColor) this));
+            }
+            else if (type == ConfigType.BLOCK_STATE)
+            {
+                configWidth -= 22; // adjust the width to match other configs due to the block icon display
+                configOption.colorDisplayPosX = x + configWidth + 2;
+                configOption.addWidget(new WidgetBlockStateIcon(configOption.colorDisplayPosX, y + 1, 18, 18, (IConfigBlockState) this));
+            }
+            else if (type == ConfigType.INTEGER || type == ConfigType.DOUBLE || type == ConfigType.FLOAT)
+            {
+                configWidth -= 18;
+                configOption.colorDisplayPosX = x + configWidth + 2;
+            }
+            
+            if ((type == ConfigType.INTEGER || type == ConfigType.DOUBLE || type == ConfigType.FLOAT) &&
+                this instanceof IConfigSlider && ((IConfigSlider) this).shouldUseSlider())
+            {
+                configOption.addConfigSliderEntry(x, y, resetX, configWidth, configHeight, (IConfigSlider) this);
+            }
+            else
+            {
+                TextFieldType textType = TextFieldType.STRING.setMaxLength(configOption.maxTextfieldTextLength);
+                
+                if (type == ConfigType.INTEGER)
+                {
+                    textType = TextFieldType.INTEGER;
+                }
+                else if (type == ConfigType.DOUBLE)
+                {
+                    textType = TextFieldType.DOUBLE;
+                }
+                else if (type == ConfigType.FLOAT)
+                {
+                    textType = TextFieldType.FLOAT;
+                }
+                else if (type == ConfigType.COLOR)
+                {
+                    textType = TextFieldType.STRING.setMaxLength(12);
+                }
+                else if (type == ConfigType.BLOCK_STATE)
+                {
+                    textType = TextFieldType.BLOCK_STATE;
+                }
+                
+                configOption.addConfigTextFieldEntry(x, y, resetX, configWidth, configHeight, (IConfigValue) this, textType);
+            }
+            
+            if (type != ConfigType.COLOR && this instanceof IConfigSlider)
+            {
+                IGuiIcon icon = ((IConfigSlider) this).shouldUseSlider() ? MaLiLibIcons.BTN_TXTFIELD : MaLiLibIcons.BTN_SLIDER;
+                ButtonGeneric toggleBtn = new ButtonGeneric(configOption.colorDisplayPosX, y + 2, icon);
+                configOption.addButton(toggleBtn, new WidgetConfigOption.ListenerSliderToggle((IConfigSlider) this));
+            }
+        }
+        else if (type == ConfigType.TABLE || this instanceof IConfigTable)
+        {
+            ConfigButtonTable optionButton = new ConfigButtonTable(x, y, configWidth, configHeight, (IConfigTable) this, configOption.host, configOption.host.getDialogHandler());
+            configOption.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) this, optionButton);
+        }
     }
 }

--- a/src/main/java/fi/dy/masa/malilib/config/options/table/ConfigTable.java
+++ b/src/main/java/fi/dy/masa/malilib/config/options/table/ConfigTable.java
@@ -8,6 +8,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.button.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -19,8 +23,6 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.util.ExtraCodecs;
 
 import fi.dy.masa.malilib.MaLiLib;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigTable;
 import fi.dy.masa.malilib.config.options.ConfigBase;
 import fi.dy.masa.malilib.config.options.table.type.*;
 import fi.dy.masa.malilib.util.StringUtils;
@@ -713,5 +715,37 @@ public class ConfigTable extends ConfigBase<ConfigTable> implements IConfigTable
 
 			return new ConfigTable(this.name, this.comment, this.prettyName, this.translatedName, this.displayString, this.defaultValue, this.labels, this.showEntryNumbers, this.allowAddNewEntry, this.types);
 		}
+	}
+	
+	@Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+		
+		y += 1;
+		int configHeight = 20;
+		
+		String configName = getConfigGuiDisplayName();
+		
+		configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+		
+		String comment;
+		IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+		
+		if (infoProvider != null)
+		{
+			comment = infoProvider.getHoverInfo(this);
+		}
+		else
+		{
+			comment = getComment();
+		}
+		
+		if (comment != null)
+		{
+			configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+		}
+		
+		x += labelWidth + 10;
+		
+		ConfigButtonTable optionButton = new ConfigButtonTable(x, y, configWidth, configHeight, this, configOption.host, configOption.host.getDialogHandler());
+		configOption.addConfigButtonEntry(x + configWidth + 2, y, this, optionButton);
 	}
 }

--- a/src/main/java/fi/dy/masa/malilib/gui/widgets/WidgetConfigOption.java
+++ b/src/main/java/fi/dy/masa/malilib/gui/widgets/WidgetConfigOption.java
@@ -13,10 +13,7 @@ import fi.dy.masa.malilib.config.options.*;
 import fi.dy.masa.malilib.gui.GuiBase;
 import fi.dy.masa.malilib.gui.GuiConfigsBase.ConfigOptionWrapper;
 import fi.dy.masa.malilib.gui.GuiTextFieldGeneric;
-import fi.dy.masa.malilib.gui.MaLiLibIcons;
 import fi.dy.masa.malilib.gui.button.*;
-import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
-import fi.dy.masa.malilib.gui.interfaces.IGuiIcon;
 import fi.dy.masa.malilib.gui.interfaces.IKeybindConfigGui;
 import fi.dy.masa.malilib.gui.interfaces.ISliderCallback;
 import fi.dy.masa.malilib.gui.wrappers.TextFieldType;
@@ -29,10 +26,10 @@ import fi.dy.masa.malilib.util.GuiUtils;
 public class WidgetConfigOption extends WidgetConfigOptionBase<ConfigOptionWrapper>
 {
     protected final ConfigOptionWrapper wrapper;
-    protected final IKeybindConfigGui host;
+    public final IKeybindConfigGui host;
     @Nullable protected final KeybindSettings initialKeybindSettings;
     @Nullable protected ImmutableList<@NotNull String> initialStringList;
-    protected int colorDisplayPosX;
+    public int colorDisplayPosX;
     private boolean initialBoolean;
 
     public WidgetConfigOption(int x, int y, int width, int height, int labelWidth, int configWidth,
@@ -82,7 +79,7 @@ public class WidgetConfigOption extends WidgetConfigOptionBase<ConfigOptionWrapp
 
 			if (config != null)
 			{
-				this.addConfigOption(x, y, labelWidth, configWidth, config);
+				config.addConfigOption(x, y, labelWidth, configWidth, this);
 			}
         }
         else
@@ -92,186 +89,6 @@ public class WidgetConfigOption extends WidgetConfigOptionBase<ConfigOptionWrapp
             this.initialKeybindSettings = null;
 
             this.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, wrapper.getLabel());
-        }
-    }
-
-    protected void addConfigOption(int x, int y, int labelWidth, int configWidth, IConfigBase config)
-    {
-        ConfigType type = config.getType();
-
-        y += 1;
-        int configHeight = 20;
-
-        String configName = config.getConfigGuiDisplayName();
-
-        // DEBUG ONLY
-        /*
-        if (config.getConfigGuiDisplayName().contains(".config"))
-        {
-            configName = StringUtils.getTranslatedOrFallback(config.getConfigGuiDisplayName(), config.getConfigGuiDisplayName());
-
-            if (configName != null)
-            {
-                int calc = super.getWidth() - configName.length();
-
-                MaLiLib.logger.error("addConfigOption(): configName [{}] (length: {}) // super.width [{}] // calc [{}] // old labelWidth [{}]", configName, configName.length(), super.getWidth(), calc, labelWidth);
-
-                if (labelWidth > super.getWidth() && configName.length() <= calc)
-                {
-                    labelWidth = Math.max(calc, this.getStringWidth(configName));
-                }
-
-                MaLiLib.logger.error("addConfigOption(): configName [{}] (length: {}) // new labelWidth [{}]", configName, configName.length(), labelWidth);
-            }
-            else
-            {
-                configName = config.getConfigGuiDisplayName();
-            }
-        }
-        else
-        {
-            configName = config.getConfigGuiDisplayName();
-        }
-        MaLiLib.logger.error("addConfigOption(): configName [{}] (width: {}), labelWidth [{}]", configName, configName.length(), labelWidth);
-         */
-
-        this.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
-
-        String comment;
-        IConfigInfoProvider infoProvider = this.host.getHoverInfoProvider();
-
-        if (infoProvider != null)
-        {
-            comment = infoProvider.getHoverInfo(config);
-        }
-        else
-        {
-            comment = config.getComment();
-        }
-
-        if (comment != null)
-        {
-            this.addConfigComment(x, y + 5, labelWidth, 12, comment);
-        }
-
-        x += labelWidth + 10;
-
-        if (config instanceof BooleanHotkeyGuiWrapper wrapper)
-        {
-            IConfigBoolean booleanConfig = wrapper.getBooleanConfig();
-            IKeybind keybind = wrapper.getKeybind();
-            this.addBooleanAndHotkeyWidgets(x, y, configWidth, wrapper, booleanConfig, keybind);
-        }
-        else if (config instanceof ConfigBooleanHotkeyed hotkeyedBoolean)
-        {
-            IKeybind keybind = hotkeyedBoolean.getKeybind();
-            this.addBooleanAndHotkeyWidgets(x, y, configWidth, hotkeyedBoolean, hotkeyedBoolean, keybind);
-        }
-        else if (type == ConfigType.BOOLEAN)
-        {
-            ConfigButtonBoolean optionButton = new ConfigButtonBoolean(x, y, configWidth, configHeight, (IConfigBoolean) config);
-            this.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) config, optionButton);
-        }
-        else if (type == ConfigType.OPTION_LIST)
-        {
-            ConfigButtonOptionList optionButton = new ConfigButtonOptionList(x, y, configWidth, configHeight, (IConfigOptionList) config);
-            this.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) config, optionButton);
-        }
-        else if (type == ConfigType.OPTION_VALUES)
-        {
-	        ConfigButtonOptionValues optionButton = new ConfigButtonOptionValues(x, y, configWidth, configHeight, (IConfigOptionValues<?>) config);
-	        this.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) config, optionButton);
-        }
-        else if (type == ConfigType.STRING_LIST)
-        {
-            ConfigButtonStringList optionButton = new ConfigButtonStringList(x, y, configWidth, configHeight, (IConfigStringList) config, this.host, this.host.getDialogHandler());
-            this.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) config, optionButton);
-        }
-        else if (type == ConfigType.LOCKED_LIST)
-        {
-            ConfigButtonLockedList optionButton = new ConfigButtonLockedList(x, y, configWidth, configHeight, (IConfigLockedList) config, this.host, this.host.getDialogHandler());
-            this.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) config, optionButton);
-        }
-        else if (type == ConfigType.COLOR_LIST)
-        {
-            ConfigButtonColorList optionButton = new ConfigButtonColorList(x, y, configWidth, configHeight, (IConfigColorList) config, this.host, this.host.getDialogHandler());
-            this.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) config, optionButton);
-        }
-        else if (type == ConfigType.HOTKEY)
-        {
-            this.addHotkeyConfigElements(x, y, configWidth, config.getName(), (IHotkey) config);
-        }
-        else if (type == ConfigType.STRING ||
-                 type == ConfigType.COLOR ||
-                 type == ConfigType.INTEGER ||
-                 type == ConfigType.DOUBLE ||
-                 type == ConfigType.FLOAT ||
-                 type == ConfigType.BLOCK_STATE)
-        {
-            int resetX = x + configWidth + 2;
-
-            if (type == ConfigType.COLOR)
-            {
-                configWidth -= 22; // adjust the width to match other configs due to the color display
-                this.colorDisplayPosX = x + configWidth + 2;
-                this.addWidget(new WidgetColorIndicator(this.colorDisplayPosX, y + 1, 18, 18, (IConfigColor) config));
-            }
-			else if (type == ConfigType.BLOCK_STATE)
-            {
-	            configWidth -= 22; // adjust the width to match other configs due to the block icon display
-	            this.colorDisplayPosX = x + configWidth + 2;
-	            this.addWidget(new WidgetBlockStateIcon(this.colorDisplayPosX, y + 1, 18, 18, (IConfigBlockState) config));
-            }
-            else if (type == ConfigType.INTEGER || type == ConfigType.DOUBLE || type == ConfigType.FLOAT)
-            {
-                configWidth -= 18;
-                this.colorDisplayPosX = x + configWidth + 2;
-            }
-
-            if ((type == ConfigType.INTEGER || type == ConfigType.DOUBLE || type == ConfigType.FLOAT) &&
-                config instanceof IConfigSlider && ((IConfigSlider) config).shouldUseSlider())
-            {
-                this.addConfigSliderEntry(x, y, resetX, configWidth, configHeight, (IConfigSlider) config);
-            }
-            else
-            {
-                TextFieldType textType = TextFieldType.STRING.setMaxLength(this.maxTextfieldTextLength);
-
-                if (type == ConfigType.INTEGER)
-                {
-                    textType = TextFieldType.INTEGER;
-                }
-                else if (type == ConfigType.DOUBLE)
-                {
-                    textType = TextFieldType.DOUBLE;
-                }
-                else if (type == ConfigType.FLOAT)
-                {
-                    textType = TextFieldType.FLOAT;
-                }
-                else if (type == ConfigType.COLOR)
-                {
-                    textType = TextFieldType.STRING.setMaxLength(12);
-                }
-				else if (type == ConfigType.BLOCK_STATE)
-                {
-					textType = TextFieldType.BLOCK_STATE;
-                }
-
-                this.addConfigTextFieldEntry(x, y, resetX, configWidth, configHeight, (IConfigValue) config, textType);
-            }
-
-            if (type != ConfigType.COLOR && config instanceof IConfigSlider)
-            {
-                IGuiIcon icon = ((IConfigSlider) config).shouldUseSlider() ? MaLiLibIcons.BTN_TXTFIELD : MaLiLibIcons.BTN_SLIDER;
-                ButtonGeneric toggleBtn = new ButtonGeneric(this.colorDisplayPosX, y + 2, icon);
-                this.addButton(toggleBtn, new ListenerSliderToggle((IConfigSlider) config));
-            }
-        }
-		else if (type == ConfigType.TABLE || config instanceof IConfigTable)
-        {
-			ConfigButtonTable optionButton = new ConfigButtonTable(x, y, configWidth, configHeight, (IConfigTable) config, this.host, this.host.getDialogHandler());
-	        this.addConfigButtonEntry(x + configWidth + 2, y, (IConfigResettable) config, optionButton);
         }
     }
 
@@ -346,13 +163,13 @@ public class WidgetConfigOption extends WidgetConfigOptionBase<ConfigOptionWrapp
             this.lastAppliedValue = config.getStringValue();
         }
     }
-
-    protected void addConfigComment(int x, int y, int width, int height, String comment)
+	
+	public void addConfigComment(int x, int y, int width, int height, String comment)
     {
         this.addWidget(new WidgetHoverInfo(x, y, width, height, comment));
     }
-
-    protected void addHotkeyConfigElements(int x, int y, int configWidth, String configName, IHotkey hotkey)
+	
+	public void addHotkeyConfigElements(int x, int y, int configWidth, String configName, IHotkey hotkey)
     {
         configWidth -= 22; // adjust the width to match other configs due to the settings widget
         IKeybind keybind = hotkey.getKeybind();
@@ -365,8 +182,8 @@ public class WidgetConfigOption extends WidgetConfigOptionBase<ConfigOptionWrapp
         this.addButton(keybindButton, this.host.getButtonPressListener());
         this.addKeybindResetButton(x, y, keybind, keybindButton);
     }
-
-    protected void addBooleanAndHotkeyWidgets(int x, int y, int configWidth,
+	
+	public void addBooleanAndHotkeyWidgets(int x, int y, int configWidth,
                                               IConfigResettable resettableConfig,
                                               IConfigBoolean booleanConfig,
                                               IKeybind keybind)
@@ -393,8 +210,8 @@ public class WidgetConfigOption extends WidgetConfigOptionBase<ConfigOptionWrapp
         this.addButton(keybindButton, this.host.getButtonPressListener());
         this.addButton(resetButton, resetListener);
     }
-
-    protected void addConfigButtonEntry(int xReset, int yReset, IConfigResettable config, ButtonBase optionButton)
+	
+	public void addConfigButtonEntry(int xReset, int yReset, IConfigResettable config, ButtonBase optionButton)
     {
         ButtonGeneric resetButton = this.createResetButton(xReset, yReset, config);
         ConfigOptionChangeListenerButton listenerChange = new ConfigOptionChangeListenerButton(config, resetButton, null);
@@ -404,7 +221,7 @@ public class WidgetConfigOption extends WidgetConfigOptionBase<ConfigOptionWrapp
         this.addButton(resetButton, listenerReset);
     }
 
-    protected void addConfigTextFieldEntry(int x, int y, int resetX, int configWidth, int configHeight, IConfigValue config, TextFieldType type)
+    public void addConfigTextFieldEntry(int x, int y, int resetX, int configWidth, int configHeight, IConfigValue config, TextFieldType type)
     {
         GuiTextFieldGeneric field = this.createTextField(x, y + 1, configWidth - 4, configHeight - 3);
         field.setMaxLength(type.getMaxLength() > 0 ? type.getMaxLength() : this.maxTextfieldTextLength);
@@ -418,7 +235,7 @@ public class WidgetConfigOption extends WidgetConfigOptionBase<ConfigOptionWrapp
         this.addButton(resetButton, listenerReset);
     }
 
-    protected void addConfigSliderEntry(int x, int y, int resetX, int configWidth, int configHeight, IConfigSlider config)
+    public void addConfigSliderEntry(int x, int y, int resetX, int configWidth, int configHeight, IConfigSlider config)
     {
         ButtonGeneric resetButton = this.createResetButton(resetX, y, config);
         ISliderCallback callback;

--- a/src/main/java/fi/dy/masa/malilib/gui/widgets/WidgetConfigOptionBase.java
+++ b/src/main/java/fi/dy/masa/malilib/gui/widgets/WidgetConfigOptionBase.java
@@ -19,7 +19,7 @@ public abstract class WidgetConfigOptionBase<TYPE> extends WidgetListEntryBase<T
     protected final WidgetListConfigOptionsBase<?, ?> parent;
     @Nullable protected TextFieldWrapper<? extends GuiTextFieldGeneric> textField = null;
     @Nullable protected String initialStringValue;
-    protected int maxTextfieldTextLength = 65535;
+    public int maxTextfieldTextLength = 65535;
     /**
      * The last applied value for any textfield-based configs.
      * Button based (boolean, option-list) values get applied immediately upon clicking the button.

--- a/src/main/java/fi/dy/masa/malilib/gui/widgets/WidgetContainer.java
+++ b/src/main/java/fi/dy/masa/malilib/gui/widgets/WidgetContainer.java
@@ -19,15 +19,15 @@ public abstract class WidgetContainer extends WidgetBase
     {
         super(x, y, width, height);
     }
-
-    protected <T extends WidgetBase> T addWidget(T widget)
+    
+    public <T extends WidgetBase> T addWidget(T widget)
     {
         this.subWidgets.add(widget);
 
         return widget;
     }
 
-    protected <T extends ButtonBase> T addButton(T button, IButtonActionListener listener)
+    public <T extends ButtonBase> T addButton(T button, IButtonActionListener listener)
     {
         button.setActionListener(listener);
         this.addWidget(button);
@@ -35,7 +35,7 @@ public abstract class WidgetContainer extends WidgetBase
         return button;
     }
 
-    protected void addLabel(int x, int y, int width, int height, int textColor, String... lines)
+    public void addLabel(int x, int y, int width, int height, int textColor, String... lines)
     {
         if (lines != null && lines.length >= 1)
         {

--- a/src/main/java/fi/dy/masa/malilib/test/config/ConfigTestEnum.java
+++ b/src/main/java/fi/dy/masa/malilib/test/config/ConfigTestEnum.java
@@ -5,6 +5,10 @@ import javax.annotation.Nullable;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
+import fi.dy.masa.malilib.config.*;
+import fi.dy.masa.malilib.gui.interfaces.IConfigInfoProvider;
+import fi.dy.masa.malilib.gui.widgets.WidgetConfigOption;
+import fi.dy.masa.malilib.hotkeys.*;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -14,14 +18,7 @@ import net.minecraft.util.StringRepresentable;
 import fi.dy.masa.malilib.MaLiLib;
 import fi.dy.masa.malilib.MaLiLibConfigs;
 import fi.dy.masa.malilib.MaLiLibReference;
-import fi.dy.masa.malilib.config.ConfigType;
-import fi.dy.masa.malilib.config.IConfigBoolean;
-import fi.dy.masa.malilib.config.IEnumBooleanHotkey;
 import fi.dy.masa.malilib.gui.GuiBase;
-import fi.dy.masa.malilib.hotkeys.IKeybind;
-import fi.dy.masa.malilib.hotkeys.KeyCallbackToggleBooleanConfigWithMessage;
-import fi.dy.masa.malilib.hotkeys.KeybindMulti;
-import fi.dy.masa.malilib.hotkeys.KeybindSettings;
 import fi.dy.masa.malilib.interfaces.IValueChangeCallback;
 import fi.dy.masa.malilib.test.render.TestRenderWalls;
 import fi.dy.masa.malilib.util.StringUtils;
@@ -432,4 +429,37 @@ public enum ConfigTestEnum implements IEnumBooleanHotkey, StringRepresentable
             MaLiLib.LOGGER.warn("Failed to set config value for '{}' from the JSON element '{}'", this.getName(), element, e);
         }
     }
+    
+    @Override public void addConfigOption(int x, int y, int labelWidth, int configWidth, WidgetConfigOption configOption) {
+        
+        final ConfigType type = ConfigType.HOTKEY;
+        
+        y += 1;
+        int configHeight = 20;
+        
+        String configName = getConfigGuiDisplayName();
+        
+        configOption.addLabel(x, y + 7, labelWidth, 8, 0xFFFFFFFF, configName);
+        
+        String comment;
+        IConfigInfoProvider infoProvider = configOption.host.getHoverInfoProvider();
+        
+        if (infoProvider != null)
+        {
+            comment = infoProvider.getHoverInfo(this);
+        }
+        else
+        {
+            comment = getComment();
+        }
+        
+        if (comment != null)
+        {
+            configOption.addConfigComment(x, y + 5, labelWidth, 12, comment);
+        }
+        
+        x += labelWidth + 10;
+		
+		configOption.addHotkeyConfigElements(x, y, configWidth, getName(), this);
+	}
 }


### PR DESCRIPTION
将WidgetConfigOption中的addConfigOption提取到了IConfigBase中，让配置类型自定义按钮而不是在WidgetConfigOption中写一大串的if-else，同时也就增强了其可拓展性。

另外能告诉我fi.dy.masa.malilib.config.options.ConfigTypeWrapper是干什么用的吗？

其实我都想把fi.dy.masa.malilib.config.ConfigType删了，这种enum只会是拓展性的枷锁

还有一个想法是在fi.dy.masa.malilib.config.options.ConfigBase或者新建一个继承了它的子类中写一个addConfigOption的默认实现，使用“按钮类型+按钮宽度权重”的方式生成按钮，其中“按钮类型”也不是enum而是一个“接收按钮位置信息返回按钮对象”的接口，我在我的LPCTools mod中就是这么做的，能在保证强拓展性的同时易于构建新配置。

Extracted the addConfigOption method from WidgetConfigOption into IConfigBase, allowing configuration types to customize buttons instead of writing lengthy if-else chains in WidgetConfigOption. This also improves its extensibility.

Additionally, could you explain what fi.dy.masa.malilib.config.options.ConfigTypeWrapper is used for?
In fact, I’m considering removing fi.dy.masa.malilib.config.ConfigType entirely, as such enums only become constraints to extensibility.

Another idea is to write a default implementation of addConfigOption in fi.dy.masa.malilib.config.options.ConfigBase or in a new subclass that inherits from it. This implementation would generate buttons using a "button type + button width weight" approach, where "button type" is not an enum but an interface that "receives button position information and returns a button object." I’ve implemented this in my LPCTools mod, which ensures strong extensibility while making it easy to create new configurations.