### PR TITLE
Fix IncompatibleClassChangeError on MC 26.2: EditBox.onValueChange is now final

### DIFF
--- a/src/main/java/fi/dy/masa/malilib/gui/GuiTextFieldDouble.java
+++ b/src/main/java/fi/dy/masa/malilib/gui/GuiTextFieldDouble.java
@@ -15,7 +15,7 @@ public class GuiTextFieldDouble extends GuiTextFieldGeneric
         super(x, y, width, height, fontRenderer);
 
 //        this.setTextPredicate(input -> input.isEmpty() || PATTERN_NUMBER.matcher(input).matches());
-	    this.setResponder(this::onValueChange);
+	    this.setResponder(this::onTextChanged);
     }
 
 	protected boolean testDouble(String input)
@@ -46,7 +46,7 @@ public class GuiTextFieldDouble extends GuiTextFieldGeneric
 		return -1;
 	}
 
-	protected void onValueChange(String newText)
+	protected void onTextChanged(String newText)
 	{
 		if (!this.testDouble(newText))
 		{

--- a/src/main/java/fi/dy/masa/malilib/gui/GuiTextFieldInteger.java
+++ b/src/main/java/fi/dy/masa/malilib/gui/GuiTextFieldInteger.java
@@ -13,7 +13,7 @@ public class GuiTextFieldInteger extends GuiTextFieldGeneric
         super(x, y, width, height, fontRenderer);
 
 //        this.setFilter(input -> input.isEmpty() || PATTERN_NUMBER.matcher(input).matches());
-		this.setResponder(this::onValueChange);
+		this.setResponder(this::onTextChanged);
     }
 
 	protected boolean testInteger(String input)
@@ -28,7 +28,7 @@ public class GuiTextFieldInteger extends GuiTextFieldGeneric
 		return false;
 	}
 
-	protected void onValueChange(String newText)
+	protected void onTextChanged(String newText)
 	{
 		if (!this.testInteger(newText))
 		{


### PR DESCRIPTION
## Problem

On Minecraft **26.2** (release), the game hard-crashes at class-load time as soon as malilib's numeric text fields are linked — e.g. when the in-game info overlay renders (`InfoUtils.renderInGameMessages`) or a config screen with a numeric field is opened:

```
java.lang.IncompatibleClassChangeError: class fi.dy.masa.malilib.gui.GuiTextFieldDouble
overrides final method net.minecraft.client.gui.components.EditBox.onValueChange(Ljava/lang/String;)V
    at java.base/java.lang.ClassLoader.defineClass1(Native Method)
    ...
    at knot//fi.dy.masa.malilib.util.InfoUtils.renderInGameMessages(InfoUtils.java:192)
```

## Root cause

`GuiTextFieldDouble` and `GuiTextFieldInteger` declare a method `onValueChange(String)` whose name+signature exactly match `EditBox.onValueChange(String)`, which is **`final`** in the 26.2 release.

The JVM treats any same-signature subclass method as an override **at link time**, independent of the `@Override` annotation (which is only a compile-time assertion). So the classes fail verification the moment they're loaded. The current 0.29.0 build only compiled because it was built against a 26.2 pre-release where this method was not yet `final`.

## Fix

Rename the change-detection callback to `onTextChanged(String)` so it no longer collides with the final `EditBox` method. The callback is already wired through `EditBox.setResponder(...)`, so no override is required — purely a rename, no behavior change.

## Verification

Builds cleanly against release **26.2** with JDK 25 (`gradlew build` → `BUILD SUCCESSFUL`); `javap` on the compiled class confirms it now declares only `onTextChanged(String)` and no longer `onValueChange`, so the class links without `IncompatibleClassChangeError`.

Reported against: MC 26.2, Fabric Loader 0.19.3, malilib 0.29.0, Litematica 0.28.0.